### PR TITLE
README.md: fix DERP map link punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ followed by base64-encoded [CBOR](https://cbor.io/) containing:
 
 - The server's WireGuard public key (Curve25519, 32 bytes)
 - DERP info. Either:
-  1. a small integer referencing one of the default [Tailscale-run tailcat servers](https://tailcat.dev/derpmap.json)), or
+  1. a small integer referencing one of the default [Tailscale-run tailcat servers](https://tailcat.dev/derpmap.json), or
   2. full DERP server metadata, to either use a custom DERP server, or to avoid the client needing a potential round-trip to fetch the latest DERP map (the server's `--full-address` flag and the `tailcat resolve` subcommand produce this form)
 
 A typical token with just an integer region ID is around 50 bytes. With embedded


### PR DESCRIPTION
## Summary
- remove an extra closing parenthesis from the DERP map link in the connection-token section

## Verification
- `git diff --check`
- direct inspection of the affected README line

Note: I could not run the Go test suite locally because this environment does not have the `go` binary installed.