### PR TITLE
fix(ssh): forward custom DERP map to ProxyCommand

### DIFF
--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/tailscale/tailcat"
 	"tailscale.com/types/logger"
 )
 
@@ -63,12 +64,23 @@ func clientSSHMode(logf logger.Logf) {
 		"-o", "StrictHostKeyChecking no",
 		"-o", "UserKnownHostsFile /dev/null",
 		"-o", "LogLevel ERROR",
-		"-o", fmt.Sprintf("ProxyCommand=%s --key=%q %s %s", exe, *flagKey, connBlobStr, portOrIPPort),
+		"-o", "ProxyCommand=" + sshProxyCommand(exe, *flagKey, *flagDERPMapURL, connBlobStr, portOrIPPort),
 		sshDst,
 	}
 	argv = append(argv, cmdArgs...)
 	err = syscall.Exec(sshExe, argv, os.Environ())
 	log.Fatalf("failed to exec: %v", err)
+}
+
+// sshProxyCommand returns the command passed to OpenSSH to connect the SSH
+// client to a tailcat server. The command is run by OpenSSH, so values that
+// can contain shell-special characters must be quoted.
+func sshProxyCommand(exe, keyName, derpMapURL, connBlob, portOrIPPort string) string {
+	cmd := fmt.Sprintf("%s --key=%q", exe, keyName)
+	if derpMapURL != tailcat.DefaultDERPMapURL {
+		cmd += fmt.Sprintf(" --derpmap-url=%q", derpMapURL)
+	}
+	return fmt.Sprintf("%s %s %s", cmd, connBlob, portOrIPPort)
 }
 
 // sshDestHost returns the hostname to give the system ssh client as the

--- a/cmd/tailcat/ssh_test.go
+++ b/cmd/tailcat/ssh_test.go
@@ -8,7 +8,31 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/tailscale/tailcat"
 )
+
+func TestSSHProxyCommandDERPMap(t *testing.T) {
+	const (
+		exe  = "/path/to/tailcat"
+		key  = "client-default"
+		blob = "tc-short-blob"
+		port = "22"
+		url  = "https://derp.example.com/derpmap.json"
+	)
+
+	got := sshProxyCommand(exe, key, url, blob, port)
+	want := exe + ` --key="client-default" --derpmap-url="https://derp.example.com/derpmap.json" tc-short-blob 22`
+	if got != want {
+		t.Errorf("sshProxyCommand with custom DERP map = %q; want %q", got, want)
+	}
+
+	got = sshProxyCommand(exe, key, tailcat.DefaultDERPMapURL, blob, port)
+	want = exe + ` --key="client-default" tc-short-blob 22`
+	if got != want {
+		t.Errorf("sshProxyCommand with default DERP map = %q; want %q", got, want)
+	}
+}
 
 func TestSSHDestHost(t *testing.T) {
 	// A realistic ConnBlob, taken from an existing test fixture elsewhere


### PR DESCRIPTION
## Fix tailcat ssh with custom --derpmap-url

  ### Summary

  Fixes an issue where tailcat ssh could not connect using a short, RegionID-based token when --derpmap-url specified a custom DERP map.

  tailcat ssh launches OpenSSH with a ProxyCommand that invokes tailcat again. That internal tailcat command forwarded --key, but not --derpmap-url, so it fell back to the default DERP map and could not resolve custom
  RegionIDs.

  ### Change

  When a non-default DERP map URL is configured, the generated ProxyCommand now includes it:

  tailcat --key=... --derpmap-url=https://derp.example.com/derpmap.json <TOKEN> 22

  Default-map behavior remains unchanged.

  ### Test coverage

  Added unit coverage verifying that:

  - A custom DERP map URL is included in the SSH ProxyCommand.
  - The default DERP map URL is not unnecessarily included.
