### PR TITLE
tailcat: add application-layer UDP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,37 @@ $ ./client tcomFwWCAWf933BLELdzd3RkHiOufJ...
 hello from port 80
 ```
 
+UDP uses a connected packet connection for each client flow, preserving
+datagram boundaries and both endpoint addresses:
+
+```go
+s.OnUDP = func(port uint16) func(tailcat.ConnPacketConn) {
+	if port != 53 {
+		return nil
+	}
+	return func(c tailcat.ConnPacketConn) {
+		defer c.Close()
+		buf := make([]byte, tailcat.MaxUDPPayload)
+		for {
+			n, err := c.Read(buf)
+			if err != nil {
+				return
+			}
+			c.Write(buf[:n])
+		}
+	}
+}
+
+pc, err := cl.DialUDPPort(context.Background(), 53)
+```
+
+`ConnPacketConn` implements both `net.Conn` and `net.PacketConn`. Keep payloads
+at or below `tailcat.MaxUDPPayload` (1232 bytes) to fit the IPv6 tunnel MTU
+without fragmentation. Use `OnUDPForward` and `DialUDP` for exit-node traffic;
+`ProxyPacketConns` provides datagram-safe bidirectional forwarding. Inactive
+server-side UDP flows close after `tailcat.DefaultUDPIdleTimeout` (two minutes);
+set `Server.UDPIdleTimeout` to change the timeout.
+
 ## How it works
 
 ### Tailcat addresses

--- a/cmd/tailcat/socks_test.go
+++ b/cmd/tailcat/socks_test.go
@@ -7,10 +7,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/netip"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/tailscale/tailcat"
+	"tailscale.com/net/socks5"
+	"tailscale.com/tstest/integration"
+	"tailscale.com/types/logger"
 )
 
 func TestClassifySOCKSAddr(t *testing.T) {
@@ -207,5 +215,383 @@ func TestNormalizeListenAddrPort(t *testing.T) {
 				t.Fatalf("normalizeListenAddrPort(%q) = %q; want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDialSOCKSTarget exercises the SOCKS dialer used by "tailcat socks"
+// against a live server: UDP ASSOCIATE targets must ride the tailcat UDP
+// APIs (DialUDPPort/DialUDP) while TCP keeps using the TCP dialers.
+func TestDialSOCKSTarget(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, testLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	backend, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { backend.Close() })
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			n, src, err := backend.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			if _, err := backend.WriteToUDP(buf[:n], src); err != nil {
+				return
+			}
+		}
+	}()
+	backendAddr := backend.LocalAddr().(*net.UDPAddr).AddrPort()
+
+	s := &tailcat.Server{Logf: testLogger(t, "server"), Region: reg}
+	t.Cleanup(func() { s.Close() })
+	s.OnUDP = func(port uint16) func(tailcat.ConnPacketConn) {
+		if port != 53 {
+			return nil
+		}
+		return func(c tailcat.ConnPacketConn) {
+			defer c.Close()
+			buf := make([]byte, 32)
+			n, err := c.Read(buf)
+			if err != nil {
+				return
+			}
+			c.Write(buf[:n])
+		}
+	}
+	s.OnTCP = func(port uint16) func(net.Conn) {
+		if port != 80 {
+			return nil
+		}
+		return func(c net.Conn) {
+			defer c.Close()
+			buf := make([]byte, 32)
+			n, err := c.Read(buf)
+			if err != nil {
+				return
+			}
+			c.Write(buf[:n])
+		}
+	}
+	s.OnUDPForward = func(dst netip.AddrPort) func(tailcat.ConnPacketConn) {
+		if dst != backendAddr {
+			return nil
+		}
+		return func(c tailcat.ConnPacketConn) {
+			upstream, err := net.DialUDP("udp4", nil, net.UDPAddrFromAddrPort(dst))
+			if err != nil {
+				c.Close()
+				return
+			}
+			tailcat.ProxyPacketConns(c, upstream)
+		}
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	cl := &tailcat.Client{Server: s.TailcatAddr(), Logf: testLogger(t, "client")}
+	t.Cleanup(func() { cl.Close() })
+	pingUntilDirect(t, cl)
+	clientForAddr := func(tailcat.Addr) *tailcat.Client { return cl }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("udp_to_server", func(t *testing.T) {
+		c, err := dialSOCKSTarget(ctx, "udp", socksTarget{toServer: true, port: 53}, cl, clientForAddr)
+		if err != nil {
+			t.Fatalf("dial udp to server: %v", err)
+		}
+		defer c.Close()
+		c.SetDeadline(time.Now().Add(5 * time.Second))
+		if _, err := c.Write([]byte("udp-server")); err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 32)
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("read udp echo: %v", err)
+		}
+		if got := string(buf[:n]); got != "udp-server" {
+			t.Fatalf("udp echo = %q; want %q", got, "udp-server")
+		}
+	})
+
+	t.Run("udp_addr", func(t *testing.T) {
+		c, err := dialSOCKSTarget(ctx, "udp", socksTarget{addr: s.TailcatAddr(), port: 53}, cl, clientForAddr)
+		if err != nil {
+			t.Fatalf("dial udp to addr: %v", err)
+		}
+		defer c.Close()
+		c.SetDeadline(time.Now().Add(5 * time.Second))
+		if _, err := c.Write([]byte("udp-blob")); err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 32)
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("read udp echo: %v", err)
+		}
+		if got := string(buf[:n]); got != "udp-blob" {
+			t.Fatalf("udp echo = %q; want %q", got, "udp-blob")
+		}
+	})
+
+	t.Run("udp_exit_node", func(t *testing.T) {
+		c, err := dialSOCKSTarget(ctx, "udp", socksTarget{dst: backendAddr}, cl, clientForAddr)
+		if err != nil {
+			t.Fatalf("dial udp exit node: %v", err)
+		}
+		defer c.Close()
+		c.SetDeadline(time.Now().Add(5 * time.Second))
+		if _, err := c.Write([]byte("udp-exit")); err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 32)
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("read udp echo: %v", err)
+		}
+		if got := string(buf[:n]); got != "udp-exit" {
+			t.Fatalf("udp echo = %q; want %q", got, "udp-exit")
+		}
+	})
+
+	t.Run("tcp_to_server", func(t *testing.T) {
+		c, err := dialSOCKSTarget(ctx, "tcp", socksTarget{toServer: true, port: 80}, cl, clientForAddr)
+		if err != nil {
+			t.Fatalf("dial tcp to server: %v", err)
+		}
+		defer c.Close()
+		c.SetDeadline(time.Now().Add(5 * time.Second))
+		if _, err := c.Write([]byte("tcp-server")); err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, 32)
+		n, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("read tcp echo: %v", err)
+		}
+		if got := string(buf[:n]); got != "tcp-server" {
+			t.Fatalf("tcp echo = %q; want %q", got, "tcp-server")
+		}
+	})
+
+	t.Run("udp_no_client", func(t *testing.T) {
+		if _, err := dialSOCKSTarget(ctx, "udp", socksTarget{toServer: true, port: 53}, nil, clientForAddr); err == nil {
+			t.Fatal("dial udp without client succeeded; want error")
+		}
+	})
+}
+
+// TestSOCKSUDPAssociateEndToEnd speaks raw SOCKS5 (greeting + UDP ASSOCIATE)
+// to a real socks5.Server wired with the tailcat dialer and exchanges a
+// datagram with the tailcat server through the UDP relay. This proves the
+// full wire path, not just the dialer: relay framing, target-conn caching,
+// and the netstack packet conn behind it.
+func TestSOCKSUDPAssociateEndToEnd(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, testLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	s := &tailcat.Server{Logf: testLogger(t, "server"), Region: reg}
+	t.Cleanup(func() { s.Close() })
+	s.OnUDP = func(port uint16) func(tailcat.ConnPacketConn) {
+		if port != 53 {
+			return nil
+		}
+		return func(c tailcat.ConnPacketConn) {
+			defer c.Close()
+			buf := make([]byte, 2048)
+			n, err := c.Read(buf)
+			if err != nil {
+				return
+			}
+			c.Write(buf[:n])
+		}
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	cl := &tailcat.Client{Server: s.TailcatAddr(), Logf: testLogger(t, "client")}
+	t.Cleanup(func() { cl.Close() })
+	pingUntilDirect(t, cl)
+	clientForAddr := func(tailcat.Addr) *tailcat.Client { return cl }
+
+	socksLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { socksLn.Close() })
+	ss := &socks5.Server{
+		Logf: testLogger(t, "socks5"),
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dst, err := classifySOCKSAddr(ctx, lookupNetIP, addr)
+			if err != nil {
+				return nil, err
+			}
+			return dialSOCKSTarget(ctx, network, dst, cl, clientForAddr)
+		},
+	}
+	go func() { _ = ss.Serve(socksLn) }()
+
+	tcp, err := net.Dial("tcp", socksLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tcp.Close()
+	if err := tcp.SetDeadline(time.Now().Add(15 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Greeting: version 5, one method, no auth.
+	if _, err := tcp.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatal(err)
+	}
+	greet := make([]byte, 2)
+	if _, err := io.ReadFull(tcp, greet); err != nil {
+		t.Fatal(err)
+	}
+	if greet[0] != 0x05 || greet[1] != 0x00 {
+		t.Fatalf("socks greeting reply = %v; want [5 0]", greet)
+	}
+
+	// UDP ASSOCIATE with a wildcard expected source.
+	if _, err := tcp.Write([]byte{0x05, 0x03, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		t.Fatal(err)
+	}
+	relayAddr := readSOCKSReply(t, tcp)
+
+	// One datagram to server.tailcat:53 through the relay; the tailcat
+	// server echoes it back through the same association.
+	const payload = "socks-udp-e2e"
+	req := buildSOCKSUDP(wireDomain("server.tailcat", 53), []byte(payload))
+	udp, err := net.DialUDP("udp", nil, relayAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udp.Close()
+	if err := udp.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := udp.Write(req); err != nil {
+		t.Fatal(err)
+	}
+	resp := make([]byte, 2048)
+	n, err := udp.Read(resp)
+	if err != nil {
+		t.Fatalf("read relayed udp echo: %v", err)
+	}
+	if got := string(parseSOCKSUDP(t, resp[:n])); got != payload {
+		t.Fatalf("relayed udp echo = %q; want %q", got, payload)
+	}
+}
+
+// readSOCKSReply reads a SOCKS5 command reply and returns the bound address.
+func readSOCKSReply(t *testing.T, r io.Reader) *net.UDPAddr {
+	t.Helper()
+	hdr := make([]byte, 4)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		t.Fatal(err)
+	}
+	if hdr[0] != 0x05 || hdr[1] != 0x00 {
+		t.Fatalf("socks reply = %v; want version 5, success", hdr)
+	}
+	var ip net.IP
+	switch hdr[3] {
+	case 0x01:
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(r, b); err != nil {
+			t.Fatal(err)
+		}
+		ip = net.IP(b)
+	case 0x04:
+		b := make([]byte, 16)
+		if _, err := io.ReadFull(r, b); err != nil {
+			t.Fatal(err)
+		}
+		ip = net.IP(b)
+	default:
+		t.Fatalf("unexpected reply address type %#x", hdr[3])
+	}
+	pb := make([]byte, 2)
+	if _, err := io.ReadFull(r, pb); err != nil {
+		t.Fatal(err)
+	}
+	return &net.UDPAddr{IP: ip, Port: int(pb[0])<<8 | int(pb[1])}
+}
+
+// wireDomain encodes a domain destination for a SOCKS UDP header.
+func wireDomain(host string, port uint16) []byte {
+	b := []byte{0x03, byte(len(host))}
+	b = append(b, host...)
+	return append(b, byte(port>>8), byte(port))
+}
+
+// buildSOCKSUDP frames a payload in a SOCKS UDP request header.
+func buildSOCKSUDP(dst, payload []byte) []byte {
+	pkt := []byte{0x00, 0x00, 0x00}
+	pkt = append(pkt, dst...)
+	return append(pkt, payload...)
+}
+
+// parseSOCKSUDP strips the SOCKS UDP response header, returning the payload.
+func parseSOCKSUDP(t *testing.T, pkt []byte) []byte {
+	t.Helper()
+	if len(pkt) < 4 || pkt[0] != 0 || pkt[1] != 0 {
+		t.Fatalf("bad udp response header %v", pkt)
+	}
+	rest := pkt[3:]
+	var hlen int
+	switch rest[0] {
+	case 0x01:
+		hlen = 1 + 4 + 2
+	case 0x04:
+		hlen = 1 + 16 + 2
+	case 0x03:
+		if len(rest) < 2 {
+			t.Fatalf("short domain udp response %v", pkt)
+		}
+		hlen = 1 + 1 + int(rest[1]) + 2
+	default:
+		t.Fatalf("unexpected udp response address type %#x", rest[0])
+	}
+	if len(rest) < hlen {
+		t.Fatalf("truncated udp response %v", pkt)
+	}
+	return rest[hlen:]
+}
+
+func testLogger(t *testing.T, name string) logger.Logf {
+	t.Helper()
+	return func(format string, args ...any) {
+		t.Logf("["+name+"] "+format, args...)
+	}
+}
+
+// pingUntilDirect polls Ping until the tunnel is up, like the library's
+// PingForTest helper (which lives in the tailcat package's own tests and
+// can't be imported here).
+func pingUntilDirect(t *testing.T, cl *tailcat.Client) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for {
+		if _, err := cl.Ping(ctx); err == nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for ping: %v", ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 }

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -1025,16 +1025,7 @@ func clientSOCKSMode(logf logger.Logf, listen string, args []string) error {
 			if err != nil {
 				return nil, err
 			}
-			if dst.addr != "" {
-				return clientForAddr(dst.addr).DialTCPPort(ctx, dst.port)
-			}
-			if cl == nil {
-				return nil, errors.New("no tailcat address argument was given to \"tailcat socks\"; only tailcat address hostnames can be dialed")
-			}
-			if dst.toServer {
-				return cl.DialTCPPort(ctx, dst.port)
-			}
-			return cl.DialTCP(ctx, dst.dst)
+			return dialSOCKSTarget(ctx, network, dst, cl, clientForAddr)
 		},
 	}
 	socksAddr := "socks5h://" + socksLn.Addr().String()
@@ -1058,6 +1049,36 @@ func clientSOCKSMode(logf logger.Logf, listen string, args []string) error {
 		log.Fatalf("SOCKS5 server exited: %v", ss.Serve(socksLn))
 	}
 	return nil
+}
+
+// dialSOCKSTarget dials a classified SOCKS destination over the tailcat
+// tunnel. UDP ASSOCIATE targets (network == "udp") use the connected packet
+// connections from [tailcat.Client.DialUDPPort] and [tailcat.Client.DialUDP],
+// which satisfy net.Conn with datagram-preserving Read/Write as the SOCKS5
+// UDP relay expects; everything else dials TCP as before.
+func dialSOCKSTarget(ctx context.Context, network string, dst socksTarget, cl *tailcat.Client, clientForAddr func(tailcat.Addr) *tailcat.Client) (net.Conn, error) {
+	if network == "udp" {
+		if dst.addr != "" {
+			return clientForAddr(dst.addr).DialUDPPort(ctx, dst.port)
+		}
+		if cl == nil {
+			return nil, errors.New("no tailcat address argument was given to \"tailcat socks\"; only tailcat address hostnames can be dialed")
+		}
+		if dst.toServer {
+			return cl.DialUDPPort(ctx, dst.port)
+		}
+		return cl.DialUDP(ctx, dst.dst)
+	}
+	if dst.addr != "" {
+		return clientForAddr(dst.addr).DialTCPPort(ctx, dst.port)
+	}
+	if cl == nil {
+		return nil, errors.New("no tailcat address argument was given to \"tailcat socks\"; only tailcat address hostnames can be dialed")
+	}
+	if dst.toServer {
+		return cl.DialTCPPort(ctx, dst.port)
+	}
+	return cl.DialTCP(ctx, dst.dst)
 }
 
 // socksTarget is where a SOCKS5 destination address should be dialed.

--- a/tailcat.go
+++ b/tailcat.go
@@ -14,8 +14,9 @@
 // just like the normal Tailscale data plane. DERP remains available as a
 // fallback relay if a direct path cannot be established.
 //
-// Once connected, the two sides exchange arbitrary TCP traffic over the
-// WireGuard tunnel with no Tailscale account or coordination server required.
+// Once connected, the two sides exchange arbitrary TCP streams and UDP
+// datagrams over the WireGuard tunnel with no Tailscale account or coordination
+// server required.
 // Optionally, the server can run an SSH server on port 22, either requiring
 // authorized public keys or relying on the tunnel for client identity.
 //
@@ -83,6 +84,7 @@ import (
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/netmap"
+	"tailscale.com/types/nettype"
 	"tailscale.com/types/views"
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/mak"
@@ -390,9 +392,9 @@ func (b *locoBackend) Close() error {
 }
 
 // Server listens for clients over a WireGuard tunnel relayed through DERP.
-// Incoming TCP connections are dispatched via [Server.OnTCP] (for connections
-// addressed to the server itself) and [Server.OnTCPForward] (for connections
-// the server relays to other addresses, acting as an exit node).
+// Incoming TCP connections and UDP flows are dispatched via the OnTCP/OnUDP
+// callbacks (for traffic addressed to the server itself) and their Forward
+// counterparts (for traffic the server relays to other addresses).
 //
 // The zero value is a usable server: optionally populate the
 // configuration fields, then call [Server.Start], which picks
@@ -469,6 +471,25 @@ type Server struct {
 	// destination, not just the server's own address.
 	OnTCPForward func(netip.AddrPort) (handler func(net.Conn))
 
+	// OnUDP, if non-nil, specifies a func that returns a handler for an
+	// incoming UDP flow to the provided port. Each handler receives a connected
+	// packet connection for one client source IP:port. Datagram boundaries are
+	// preserved, and LocalAddr and RemoteAddr report the destination and source
+	// of the flow. If nil or if it returns nil, the flow is dropped.
+	//
+	// This only applies to packets addressed directly to the server node and not
+	// when being a subnet router. See OnUDPForward for relayed packets.
+	//
+	// It must be set before calling Start.
+	OnUDP func(port uint16) (handler func(ConnPacketConn))
+
+	// OnUDPForward is like OnUDP for UDP flows addressed through the server to
+	// another IP:port. Setting it also widens the packet filter installed at
+	// Start to admit UDP traffic to any destination.
+	//
+	// It must be set before calling Start.
+	OnUDPForward func(netip.AddrPort) (handler func(ConnPacketConn))
+
 	// ServedTCPPorts, if non-nil, restricts which TCP ports on the
 	// server's own address the packet filter admits new inbound
 	// connections to. If nil, connections to all ports reach OnTCP,
@@ -481,7 +502,38 @@ type Server struct {
 	//
 	// It must be set before calling Start.
 	ServedTCPPorts []filter.PortRange
+
+	// ServedUDPPorts, if non-nil, restricts which UDP ports on the server's own
+	// address the packet filter admits. If nil, packets to all ports reach
+	// OnUDP, which remains the per-flow gate either way.
+	//
+	// It must be set before calling Start.
+	ServedUDPPorts []filter.PortRange
+
+	// UDPIdleTimeout is how long an inactive incoming UDP flow remains open.
+	// A zero value uses [DefaultUDPIdleTimeout]. Successful reads and writes
+	// reset the timeout. It must be set before calling Start.
+	UDPIdleTimeout time.Duration
 }
+
+// ConnPacketConn is a connected datagram socket. Read and Write preserve UDP
+// datagram boundaries, while the net.PacketConn methods are available to code
+// that prefers packet-oriented APIs. LocalAddr and RemoteAddr identify the
+// destination and source endpoints of an incoming server flow.
+type ConnPacketConn interface {
+	net.Conn
+	net.PacketConn
+}
+
+// MaxUDPPayload is the largest UDP payload that fits the tunnel's 1280-byte
+// IPv6 MTU without IP fragmentation (1280 minus 40 bytes of IPv6 header and 8
+// bytes of UDP header). Applications should keep datagrams at or below this
+// size; larger writes are not guaranteed to reach the peer.
+const MaxUDPPayload = 1232
+
+// DefaultUDPIdleTimeout is the amount of inactivity after which an incoming
+// UDP flow is closed.
+const DefaultUDPIdleTimeout = 2 * time.Minute
 
 // Start connects to the DERP relay and begins accepting clients,
 // first picking defaults for any unset configuration fields: a new
@@ -490,6 +542,9 @@ type Server struct {
 func (s *Server) Start() error {
 	if s.lb != nil {
 		return errors.New("tailcat: Server.Start called twice")
+	}
+	if s.UDPIdleTimeout < 0 {
+		return errors.New("tailcat: Server.UDPIdleTimeout must not be negative")
 	}
 	logf := s.Logf
 	if logf == nil {
@@ -604,6 +659,26 @@ func (s *Server) Start() error {
 		}
 		return s.OnTCPForward(dst), true
 	}
+	ns.GetUDPHandlerForFlow = func(src, dst netip.AddrPort) (handler func(nettype.ConnPacketConn), intercept bool) {
+		var h func(ConnPacketConn)
+		if dst.Addr() == lb.addr {
+			if s.OnUDP != nil {
+				h = s.OnUDP(dst.Port())
+			}
+		} else if s.OnUDPForward != nil {
+			if nat64Prefix.Contains(dst.Addr()) {
+				var a4 [4]byte
+				d6 := dst.Addr().As16()
+				copy(a4[:], d6[12:16])
+				dst = netip.AddrPortFrom(netip.AddrFrom4(a4), dst.Port())
+			}
+			h = s.OnUDPForward(dst)
+		}
+		if h == nil {
+			return nil, true
+		}
+		return func(c nettype.ConnPacketConn) { h(newIdlePacketConn(c, s.udpIdleTimeout())) }, true
+	}
 	lb.ns = ns
 	sys.Set(ns)
 
@@ -630,19 +705,26 @@ func (s *Server) Start() error {
 	return nil
 }
 
-var allTCPPorts = filter.PortRange{First: 0, Last: 65535}
+func (s *Server) udpIdleTimeout() time.Duration {
+	if s.UDPIdleTimeout != 0 {
+		return s.UDPIdleTimeout
+	}
+	return DefaultUDPIdleTimeout
+}
 
-// buildFilter returns the packet filter enforcing what the server is
-// configured to serve: new inbound TCP connections are admitted only
-// to the server's own address (limited to ServedTCPPorts if set),
-// plus to any destination when OnTCPForward is set (exit node mode).
+var allPorts = filter.PortRange{First: 0, Last: 65535}
+
+// buildFilter returns the packet filter enforcing what the server is configured
+// to serve: inbound TCP connections and UDP flows are admitted only to the
+// server's own configured ports, plus to any destination for protocols whose
+// Forward callback is set (exit node mode).
 // Everything else from the tunnel is dropped before reaching
 // netstack; the OnTCP/OnTCPForward callbacks remain the
 // per-connection gates behind it.
 func (s *Server) buildFilter() *filter.Filter {
 	lb := s.lb
 
-	selfPorts := []filter.PortRange{allTCPPorts}
+	selfPorts := []filter.PortRange{allPorts}
 	if s.ServedTCPPorts != nil {
 		selfPorts = s.ServedTCPPorts
 	}
@@ -655,15 +737,39 @@ func (s *Server) buildFilter() *filter.Filter {
 		Srcs:    []netip.Prefix{allIPv6},
 		Dsts:    selfDsts,
 	}}
+	if s.OnUDP != nil {
+		udpPorts := []filter.PortRange{allPorts}
+		if s.ServedUDPPorts != nil {
+			udpPorts = s.ServedUDPPorts
+		}
+		udpDsts := make([]filter.NetPortRange, 0, len(udpPorts))
+		for _, pr := range udpPorts {
+			udpDsts = append(udpDsts, filter.NetPortRange{Net: lb.addrPrefix, Ports: pr})
+		}
+		matches = append(matches, filter.Match{
+			IPProto: views.SliceOf([]ipproto.Proto{ipproto.UDP}),
+			Srcs:    []netip.Prefix{allIPv6},
+			Dsts:    udpDsts,
+		})
+	}
 
 	var localNets netipx.IPSetBuilder
 	localNets.AddPrefix(lb.addrPrefix)
-	if s.OnTCPForward != nil {
+	if s.OnTCPForward != nil || s.OnUDPForward != nil {
 		localNets.AddPrefix(allIPv6)
+	}
+	if s.OnTCPForward != nil {
 		matches = append(matches, filter.Match{
 			IPProto: views.SliceOf([]ipproto.Proto{ipproto.TCP}),
 			Srcs:    []netip.Prefix{allIPv6},
-			Dsts:    []filter.NetPortRange{{Net: allIPv6, Ports: allTCPPorts}},
+			Dsts:    []filter.NetPortRange{{Net: allIPv6, Ports: allPorts}},
+		})
+	}
+	if s.OnUDPForward != nil {
+		matches = append(matches, filter.Match{
+			IPProto: views.SliceOf([]ipproto.Proto{ipproto.UDP}),
+			Srcs:    []netip.Prefix{allIPv6},
+			Dsts:    []filter.NetPortRange{{Net: allIPv6, Ports: allPorts}},
 		})
 	}
 	local, _ := localNets.IPSet()
@@ -1609,8 +1715,8 @@ func createEngine(logf logger.Logf, lb *locoBackend) (err error) {
 
 // Client connects to a [Server] over a WireGuard tunnel relayed through DERP.
 // Populate Server (the only required field, or use the [NewClient]
-// shorthand), then just dial: [Client.Dial], [Client.DialTCPPort],
-// and [Client.DialTCP] lazily establish the tunnel on first use,
+// shorthand), then just dial: [Client.Dial], the DialTCP methods, and the
+// DialUDP methods lazily establish the tunnel on first use,
 // picking defaults for any unset fields. [Client.Ping] does the same
 // and is useful to test connectivity first or to measure the relay
 // round-trip time.
@@ -1770,7 +1876,11 @@ func (c *Client) initLocked() error {
 		return ns.DialContextTCP(ctx, dst)
 	}
 	dialer.NetstackDialUDP = func(ctx context.Context, dst netip.AddrPort) (net.Conn, error) {
-		panic("unreachable from tailcat") // but required by Dialer currently
+		udpConn, err := ns.DialContextUDPWithBind(ctx, lb.addr, dst)
+		if err != nil {
+			return nil, err
+		}
+		return udpConn, nil
 	}
 	sys.Tun.Get().Start()
 
@@ -2022,6 +2132,42 @@ func (c *Client) DialTCP(ctx context.Context, ap netip.AddrPort) (net.Conn, erro
 	return c.lb.ns.DialContextTCP(ctx, ap)
 }
 
+// DialUDPPort opens a connected UDP packet connection to the given port on the
+// server. Each Write sends one datagram and each Read receives one datagram.
+// See [Client.Dial] for the lazy startup behavior.
+func (c *Client) DialUDPPort(ctx context.Context, port uint16) (ConnPacketConn, error) {
+	if err := c.up(ctx); err != nil {
+		return nil, err
+	}
+	return c.dialUDP(ctx, netip.AddrPortFrom(c.serverAddr, port))
+}
+
+// DialUDP opens a connected UDP packet connection to an arbitrary IP:port
+// through the server, which must be configured to forward UDP (see
+// [Server.OnUDPForward]). IPv4 addresses are mapped into the NAT64 prefix for
+// transport over the IPv6-only WireGuard tunnel.
+// See [Client.Dial] for the lazy startup behavior.
+func (c *Client) DialUDP(ctx context.Context, ap netip.AddrPort) (ConnPacketConn, error) {
+	if err := c.up(ctx); err != nil {
+		return nil, err
+	}
+	if ap.Addr().Is4() {
+		a := nat64PrefixBytes
+		a4 := ap.Addr().As4()
+		copy(a[12:], a4[:])
+		ap = netip.AddrPortFrom(netip.AddrFrom16(a), ap.Port())
+	}
+	return c.dialUDP(ctx, ap)
+}
+
+func (c *Client) dialUDP(ctx context.Context, ap netip.AddrPort) (ConnPacketConn, error) {
+	udpConn, err := c.lb.ns.DialContextUDPWithBind(ctx, c.lb.addr, ap)
+	if err != nil {
+		return nil, err
+	}
+	return udpConn, nil
+}
+
 func pfxOf(a netip.Addr) netip.Prefix {
 	return netip.PrefixFrom(a, a.BitLen())
 }
@@ -2128,6 +2274,124 @@ func gonetTCPConnInternals(c *gonet.TCPConn) (ep tcpStateEndpoint, wq *waiter.Qu
 	ep = reflect.NewAt(epv.Type(), unsafe.Pointer(epv.UnsafeAddr())).Elem().Interface().(tcpStateEndpoint)
 	wq = reflect.NewAt(wqv.Type(), unsafe.Pointer(wqv.UnsafeAddr())).Elem().Interface().(*waiter.Queue)
 	return ep, wq
+}
+
+// ProxyPacketConns copies whole datagrams between a and b until either socket
+// fails or is closed, then closes both sockets. The maximum-size UDP buffer
+// avoids turning a large datagram into multiple writes or truncating it.
+func ProxyPacketConns(a, b ConnPacketConn) {
+	done := make(chan struct{}, 2)
+	pump := func(dst, src ConnPacketConn) {
+		buf := make([]byte, 65535)
+		for {
+			n, err := src.Read(buf)
+			if err != nil {
+				break
+			}
+			if _, err := dst.Write(buf[:n]); err != nil {
+				break
+			}
+		}
+		done <- struct{}{}
+	}
+	go pump(a, b)
+	go pump(b, a)
+	<-done
+	a.Close()
+	b.Close()
+	<-done
+}
+
+// idlePacketConn closes c after timeout without a successful read or write.
+// It is used for server-side UDP flows, which do not otherwise have a natural
+// close signal from the peer.
+type idlePacketConn struct {
+	ConnPacketConn
+	timeout  time.Duration
+	timer    *time.Timer
+	deadline time.Time
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func newIdlePacketConn(c ConnPacketConn, timeout time.Duration) *idlePacketConn {
+	ic := &idlePacketConn{ConnPacketConn: c, timeout: timeout, deadline: time.Now().Add(timeout)}
+	ic.timer = time.AfterFunc(timeout, ic.checkIdle)
+	return ic
+}
+
+// checkIdle closes the flow if the deadline has passed. If activity extended
+// the deadline while the timer was firing, it reschedules instead of closing,
+// so a concurrent touch cannot be followed by a spurious close.
+func (c *idlePacketConn) checkIdle() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	if remaining := time.Until(c.deadline); remaining > 0 {
+		c.timer.Reset(remaining)
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.mu.Unlock()
+	c.ConnPacketConn.Close()
+}
+
+func (c *idlePacketConn) touch() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.deadline = time.Now().Add(c.timeout)
+	c.timer.Reset(c.timeout)
+}
+
+func (c *idlePacketConn) Read(b []byte) (int, error) {
+	n, err := c.ConnPacketConn.Read(b)
+	if err == nil {
+		c.touch()
+	}
+	return n, err
+}
+
+func (c *idlePacketConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, addr, err := c.ConnPacketConn.ReadFrom(b)
+	if err == nil {
+		c.touch()
+	}
+	return n, addr, err
+}
+
+func (c *idlePacketConn) Write(b []byte) (int, error) {
+	n, err := c.ConnPacketConn.Write(b)
+	if err == nil {
+		c.touch()
+	}
+	return n, err
+}
+
+func (c *idlePacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	n, err := c.ConnPacketConn.WriteTo(b, addr)
+	if err == nil {
+		c.touch()
+	}
+	return n, err
+}
+
+func (c *idlePacketConn) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return net.ErrClosed
+	}
+	c.closed = true
+	c.timer.Stop()
+	c.mu.Unlock()
+	return c.ConnPacketConn.Close()
 }
 
 // Status returns the current WireGuard and DERP connection status.

--- a/tailcat_test.go
+++ b/tailcat_test.go
@@ -4,6 +4,7 @@
 package tailcat
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -319,6 +320,433 @@ func TestTailcat(t *testing.T) {
 		t.Fatalf("DialTCP = %v, %v", conn, err)
 	}
 
+}
+
+func TestUDP(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, mkLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	type flow struct {
+		local, remote netip.AddrPort
+	}
+	flows := make(chan flow, 2)
+	handlerErr := make(chan error, 2)
+	var onUDPCalls atomic.Int32
+
+	s := &Server{Logf: mkLogger(t, "server"), Region: reg}
+	t.Cleanup(func() { s.Close() })
+	s.OnUDP = func(port uint16) func(ConnPacketConn) {
+		onUDPCalls.Add(1)
+		if port != 53 {
+			return nil
+		}
+		return func(c ConnPacketConn) {
+			defer c.Close()
+			local, err := netip.ParseAddrPort(c.LocalAddr().String())
+			if err != nil {
+				handlerErr <- err
+				return
+			}
+			remote, err := netip.ParseAddrPort(c.RemoteAddr().String())
+			if err != nil {
+				handlerErr <- err
+				return
+			}
+			flows <- flow{local, remote}
+			for range 2 {
+				buf := make([]byte, 65535)
+				n, err := c.Read(buf)
+				if err != nil {
+					handlerErr <- err
+					return
+				}
+				if _, err := c.Write(buf[:n]); err != nil {
+					handlerErr <- err
+					return
+				}
+			}
+			handlerErr <- nil
+		}
+	}
+	s.ServedUDPPorts = []filter.PortRange{{First: 53, Last: 53}}
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	clients := []*Client{
+		{Server: s.ConnBlob(), Logf: mkLogger(t, "client1")},
+		{Server: s.ConnBlob(), Logf: mkLogger(t, "client2")},
+	}
+	for _, c := range clients {
+		t.Cleanup(func() { c.Close() })
+		PingForTest(t, s, c)
+		pc, err := c.DialUDPPort(t.Context(), 53)
+		if err != nil {
+			t.Fatalf("DialUDPPort: %v", err)
+		}
+		defer pc.Close()
+		if err := pc.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		// MaxUDPPayload is the largest datagram that fits Tailcat's 1280-byte
+		// IPv6 tunnel MTU without fragmentation.
+		for _, payload := range [][]byte{[]byte("small datagram"), bytes.Repeat([]byte("m"), MaxUDPPayload)} {
+			if n, err := pc.Write(payload); err != nil || n != len(payload) {
+				t.Fatalf("UDP Write = %d, %v; want %d, nil", n, err, len(payload))
+			}
+			got := make([]byte, len(payload)+1)
+			n, err := pc.Read(got)
+			if err != nil {
+				t.Fatalf("UDP Read: %v", err)
+			}
+			if !bytes.Equal(got[:n], payload) {
+				t.Fatalf("UDP echo = %d bytes; want %d-byte datagram", n, len(payload))
+			}
+		}
+		gotFlow := <-flows
+		if gotFlow.local != netip.AddrPortFrom(s.Addr(), 53) {
+			t.Errorf("server flow local address = %v; want %v:53", gotFlow.local, s.Addr())
+		}
+		clientLocal, err := netip.ParseAddrPort(pc.LocalAddr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotFlow.remote != clientLocal {
+			t.Errorf("server flow remote address = %v; want client %v", gotFlow.remote, clientLocal)
+		}
+		if err := <-handlerErr; err != nil {
+			t.Fatalf("UDP handler: %v", err)
+		}
+	}
+
+	// Dialing a filtered UDP port creates a local socket immediately, but its
+	// datagrams must be silently dropped before reaching OnUDP.
+	pc, err := clients[0].DialUDPPort(t.Context(), 54)
+	if err != nil {
+		t.Fatalf("DialUDPPort(54): %v", err)
+	}
+	defer pc.Close()
+	pc.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if _, err := pc.Write([]byte("drop me")); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := pc.Read(make([]byte, 32)); err == nil {
+		t.Fatalf("filtered UDP read = %d, nil; want timeout", n)
+	} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("filtered UDP read error = %v; want timeout", err)
+	}
+	if got := onUDPCalls.Load(); got != int32(len(clients)) {
+		t.Fatalf("OnUDP called %d times; want %d served flows and no filtered flow", got, len(clients))
+	}
+}
+
+func TestUDPForward(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, mkLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	backend, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { backend.Close() })
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			n, src, err := backend.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			if _, err := backend.WriteToUDP(buf[:n], src); err != nil {
+				return
+			}
+		}
+	}()
+	backendAddr := backend.LocalAddr().(*net.UDPAddr).AddrPort()
+
+	s := &Server{Logf: mkLogger(t, "server"), Region: reg}
+	t.Cleanup(func() { s.Close() })
+	s.OnUDPForward = func(dst netip.AddrPort) func(ConnPacketConn) {
+		if dst != backendAddr {
+			return nil
+		}
+		return func(c ConnPacketConn) {
+			upstream, err := net.DialUDP("udp4", nil, net.UDPAddrFromAddrPort(dst))
+			if err != nil {
+				c.Close()
+				return
+			}
+			ProxyPacketConns(c, upstream)
+		}
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	c := &Client{Server: s.ConnBlob(), Logf: mkLogger(t, "client")}
+	t.Cleanup(func() { c.Close() })
+	PingForTest(t, s, c)
+	forwarded, err := c.DialUDP(t.Context(), backendAddr)
+	if err != nil {
+		t.Fatalf("DialUDP(%v): %v", backendAddr, err)
+	}
+	defer forwarded.Close()
+	forwarded.SetDeadline(time.Now().Add(5 * time.Second))
+	const payload = "forwarded datagram"
+	if _, err := forwarded.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64)
+	n, err := forwarded.Read(buf)
+	if err != nil {
+		t.Fatalf("reading forwarded UDP echo: %v", err)
+	}
+	if got := string(buf[:n]); got != payload {
+		t.Fatalf("forwarded UDP echo = %q; want %q", got, payload)
+	}
+}
+
+func TestUDPIdleTimeout(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, mkLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	handlerStarted := make(chan struct{})
+	handlerDone := make(chan error, 1)
+	s := &Server{
+		Logf:           mkLogger(t, "server"),
+		Region:         reg,
+		UDPIdleTimeout: 50 * time.Millisecond,
+		OnUDP: func(port uint16) func(ConnPacketConn) {
+			if port != 53 {
+				return nil
+			}
+			return func(c ConnPacketConn) {
+				defer c.Close()
+				close(handlerStarted)
+				buf := make([]byte, 1)
+				if _, err := c.Read(buf); err != nil {
+					handlerDone <- err
+					return
+				}
+				_, err := c.Read(buf)
+				handlerDone <- err
+			}
+		},
+	}
+	t.Cleanup(func() { s.Close() })
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	c := &Client{Server: s.ConnBlob(), Logf: mkLogger(t, "client")}
+	t.Cleanup(func() { c.Close() })
+	PingForTest(t, s, c)
+	pc, err := c.DialUDPPort(t.Context(), 53)
+	if err != nil {
+		t.Fatalf("DialUDPPort: %v", err)
+	}
+	defer pc.Close()
+	if _, err := pc.Write([]byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("UDP handler did not start")
+	}
+	select {
+	case err := <-handlerDone:
+		if err == nil {
+			t.Fatal("UDP flow ended without an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("UDP flow did not time out")
+	}
+}
+
+func TestServerRejectsNegativeUDPIdleTimeout(t *testing.T) {
+	s := &Server{UDPIdleTimeout: -time.Second}
+	if err := s.Start(); err == nil {
+		t.Fatal("Server.Start succeeded with a negative UDP idle timeout")
+	}
+}
+
+func TestUDPIdleTimeoutDefault(t *testing.T) {
+	if got := (&Server{}).udpIdleTimeout(); got != DefaultUDPIdleTimeout {
+		t.Fatalf("zero UDPIdleTimeout = %v; want DefaultUDPIdleTimeout %v", got, DefaultUDPIdleTimeout)
+	}
+	const custom = 5 * time.Second
+	if got := (&Server{UDPIdleTimeout: custom}).udpIdleTimeout(); got != custom {
+		t.Fatalf("custom UDPIdleTimeout = %v; want %v", got, custom)
+	}
+}
+
+func TestUDPForwardIdleTimeout(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, mkLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	backend, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { backend.Close() })
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			n, src, err := backend.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			if _, err := backend.WriteToUDP(buf[:n], src); err != nil {
+				return
+			}
+		}
+	}()
+	backendAddr := backend.LocalAddr().(*net.UDPAddr).AddrPort()
+
+	handlerDone := make(chan struct{})
+	s := &Server{
+		Logf:           mkLogger(t, "server"),
+		Region:         reg,
+		UDPIdleTimeout: 50 * time.Millisecond,
+	}
+	t.Cleanup(func() { s.Close() })
+	s.OnUDPForward = func(dst netip.AddrPort) func(ConnPacketConn) {
+		if dst != backendAddr {
+			return nil
+		}
+		return func(c ConnPacketConn) {
+			defer close(handlerDone)
+			upstream, err := net.DialUDP("udp4", nil, net.UDPAddrFromAddrPort(dst))
+			if err != nil {
+				c.Close()
+				return
+			}
+			ProxyPacketConns(c, upstream)
+		}
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	c := &Client{Server: s.ConnBlob(), Logf: mkLogger(t, "client")}
+	t.Cleanup(func() { c.Close() })
+	PingForTest(t, s, c)
+	forwarded, err := c.DialUDP(t.Context(), backendAddr)
+	if err != nil {
+		t.Fatalf("DialUDP(%v): %v", backendAddr, err)
+	}
+	defer forwarded.Close()
+	if err := forwarded.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	const payload = "forwarded datagram"
+	if _, err := forwarded.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64)
+	n, err := forwarded.Read(buf)
+	if err != nil {
+		t.Fatalf("reading forwarded UDP echo: %v", err)
+	}
+	if got := string(buf[:n]); got != payload {
+		t.Fatalf("forwarded UDP echo = %q; want %q", got, payload)
+	}
+	// Now go idle: the server-side forward flow must time out and the
+	// ProxyPacketConns handler must return.
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("forwarded UDP flow did not time out")
+	}
+}
+
+func TestUDPIdleTimeoutReset(t *testing.T) {
+	dm := integration.RunDERPAndSTUN(t, mkLogger(t, "derpstun"), "127.0.0.1")
+	reg := dm.Regions[1]
+	if reg == nil {
+		t.Fatal("no region 1 in derpmap")
+	}
+
+	handlerDone := make(chan error, 1)
+	s := &Server{
+		Logf:           mkLogger(t, "server"),
+		Region:         reg,
+		UDPIdleTimeout: 200 * time.Millisecond,
+		OnUDP: func(port uint16) func(ConnPacketConn) {
+			if port != 53 {
+				return nil
+			}
+			return func(c ConnPacketConn) {
+				defer c.Close()
+				buf := make([]byte, 32)
+				for {
+					n, err := c.Read(buf)
+					if err != nil {
+						handlerDone <- err
+						return
+					}
+					if _, err := c.Write(buf[:n]); err != nil {
+						handlerDone <- err
+						return
+					}
+				}
+			}
+		},
+	}
+	t.Cleanup(func() { s.Close() })
+	if err := s.Start(); err != nil {
+		t.Fatalf("server Start: %v", err)
+	}
+
+	c := &Client{Server: s.ConnBlob(), Logf: mkLogger(t, "client")}
+	t.Cleanup(func() { c.Close() })
+	PingForTest(t, s, c)
+	pc, err := c.DialUDPPort(t.Context(), 53)
+	if err != nil {
+		t.Fatalf("DialUDPPort: %v", err)
+	}
+	defer pc.Close()
+	if err := pc.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	// Each exchange resets the 200ms idle timer; the flow must survive
+	// well past the original deadline as long as activity continues.
+	for i := range 4 {
+		msg := []byte{byte('a' + i)}
+		if _, err := pc.Write(msg); err != nil {
+			t.Fatalf("UDP Write %d: %v", i, err)
+		}
+		buf := make([]byte, 32)
+		n, err := pc.Read(buf)
+		if err != nil {
+			t.Fatalf("UDP Read %d (flow closed despite activity): %v", i, err)
+		}
+		if !bytes.Equal(buf[:n], msg) {
+			t.Fatalf("UDP echo %d = %q; want %q", i, buf[:n], msg)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	// Now go idle: the server must close the flow.
+	select {
+	case err := <-handlerDone:
+		if err == nil {
+			t.Fatal("UDP flow ended without an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("UDP flow did not time out after going idle")
+	}
 }
 
 // TestHalfClose tests that a client's write shutdown (CloseWrite)


### PR DESCRIPTION
## Related Issue: #23 

## Summary

Adds generic application-layer UDP support to Tailcat using connected packet connections. 
Applications can now exchange UDP datagrams with a server or forward them through a Tailcat exit node while reusing the existing WireGuard, direct-path discovery, and DERP fallback data plane.

## Fix

Introduces client-side `DialUDPPort` and `DialUDP` APIs and server-side `OnUDP` and `OnUDPForward` handlers. UDP flows preserve datagram boundaries and expose their source and destination endpoints through `ConnPacketConn`.

The server packet filter now supports UDP served-port restrictions and UDP exit-node traffic. IPv4 forwarding uses the existing NAT64 mapping, and `ProxyPacketConns` provides datagram-safe bidirectional forwarding. The API documentation also defines the 1232-byte safe UDP payload limit for Tailcat’s IPv6 tunnel MTU.

## Test

Added integration tests using the existing local DERP and STUN environment.
Coverage includes datagram echoing, endpoint preservation, two simultaneous clients with independent source ports, served-port filtering, maximum safe payload delivery, and IPv4 UDP forwarding through the server.
The full Go test suite, race-enabled UDP tests, `go vet`, native and WASM builds, and headless-browser tests pass.