### PR TITLE
tailcat: reject malformed ConnBlob public keys

### DIFF
--- a/tailcat.go
+++ b/tailcat.go
@@ -174,6 +174,9 @@ func (p NodePublic) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler for CBOR deserialization.
 func (p *NodePublic) UnmarshalBinary(x []byte) error {
+	if len(x) != key.NodePublicRawLen {
+		return fmt.Errorf("invalid node public key length %d, want %d", len(x), key.NodePublicRawLen)
+	}
 	p.NodePublic = key.NodePublicFromRaw32(go4mem.B(x))
 	return nil
 }

--- a/tailcat_test.go
+++ b/tailcat_test.go
@@ -5,6 +5,7 @@ package tailcat
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/google/go-cmp/cmp"
 	"go4.org/mem"
 	"tailscale.com/tailcfg"
@@ -418,6 +420,40 @@ func TestConnBlob(t *testing.T) {
 			if diff := cmp.Diff(want, gotCI); diff != "" {
 				t.Errorf("ParseConnBlob result back diff:\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestParseConnBlobMalformedPublicKey(t *testing.T) {
+	for name, keyBytes := range map[string][]byte{
+		"short": make([]byte, key.NodePublicRawLen-1),
+		"long":  make([]byte, key.NodePublicRawLen+1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw, err := cbor.Marshal(map[string][]byte{"p": keyBytes})
+			if err != nil {
+				t.Fatal(err)
+			}
+			cb := ConnBlob("tc" + base64.RawURLEncoding.EncodeToString(raw))
+			assertParseError := func(name string, parse func() error) {
+				t.Helper()
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("%s panicked: %v", name, r)
+					}
+				}()
+				if err := parse(); err == nil {
+					t.Errorf("%s unexpectedly accepted malformed public key", name)
+				}
+			}
+			assertParseError("ParseConnBlob", func() error {
+				_, err := ParseConnBlob(cb)
+				return err
+			})
+			assertParseError("ParseConnBlobRaw", func() error {
+				_, err := ParseConnBlobRaw(cb)
+				return err
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Reject malformed public keys embedded in connection blobs instead of panicking during CBOR decoding.

## Details

`NodePublic.UnmarshalBinary` passed arbitrary CBOR byte strings directly to `key.NodePublicFromRaw32`, which panics unless the input is exactly 32 bytes.

Connection blobs can be supplied by users or discovered through DNS TXT records, so malformed input could terminate the CLI or a library process.

This change validates the byte-string length first and returns a descriptive error. Regression tests cover both short and oversized public keys through `ParseConnBlob` and `ParseConnBlobRaw`.

## Testing

- `go test . -run TestParseConnBlobMalformedPublicKey -count=1`
- `go test . -run TestConnBlob -count=1`
- `go test . -count=1`