### PR TITLE
cmd/tailcat: add verified manual release updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,29 @@ yay -S tailcat-bin
 
 ## Usage
 
+### Updates
+
+Standalone official release and tagged `go install` binaries can check for or
+install the latest stable release manually when that release contains a
+prebuilt archive for the current platform:
+
+```sh
+$ tailcat update --check
+$ tailcat update
+```
+
+The updater discovers the exact `GOOS`/`GOARCH` asset emitted by the release
+matrix, downloads it, and verifies it against the release's `checksums.txt`
+before replacing the executable. New targets using the existing GoReleaser
+archive naming template are discovered without updater code changes.
+Debian, RPM, and Arch Linux/AUR packages should instead be upgraded through
+their package manager. The same applies to Homebrew, MacPorts, WinGet, Scoop,
+Chocolatey, and Windows installer packages. Nix and container installations
+should be updated through Nix or by pulling a newer image. macOS source
+installations should currently be updated with the `go install ...@latest`
+command above until macOS archives are added to the release matrix; native
+Homebrew packaging is tracked in [#28](https://github.com/tailscale/tailcat/issues/28).
+
 ### Pipe stdin/stdout between two machines
 
 Server starts, printing out its ephemeral address:

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -131,6 +131,11 @@ Parse an address blob and print its encoded fields as JSON:
 
 	tailcat parse <addrblob>
 
+Check for or install a newer release:
+
+	tailcat update --check
+	tailcat update
+
 Resolve a short address blob into a longer self-contained one with
 embedded DERP server info (see also the server's --full-address flag):
 
@@ -195,6 +200,7 @@ func versionString() string {
 }
 
 func main() {
+	cleanupUpdateBackup()
 	flag.Usage = func() { usage("") }
 	flag.Parse()
 	if *flagReadme {
@@ -209,6 +215,10 @@ func main() {
 		tailcat.Verbose = true
 	}
 	args := flag.Args()
+	if len(args) > 0 && args[0] == "update" {
+		updateMode()
+		return
+	}
 	serverMode := len(args) == 0 || *flagServe != ""
 	if len(args) > 0 && serverMode {
 		usage("No positional arguments are valid along with --serve")

--- a/cmd/tailcat/update.go
+++ b/cmd/tailcat/update.go
@@ -1,0 +1,767 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	latestReleaseURL   = "https://api.github.com/repos/tailscale/tailcat/releases/latest"
+	updateTimeout      = 2 * time.Minute
+	maxReleaseResponse = 1 << 20   // 1 MiB
+	maxChecksums       = 1 << 20   // 1 MiB
+	maxReleaseAsset    = 128 << 20 // 128 MiB
+	maxBinary          = 128 << 20 // 128 MiB
+	maxExpandedArchive = 256 << 20 // 256 MiB
+	maxArchiveEntries  = 1024
+)
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+	Digest             string `json:"digest"`
+}
+
+type githubRelease struct {
+	TagName    string         `json:"tag_name"`
+	Draft      bool           `json:"draft"`
+	Prerelease bool           `json:"prerelease"`
+	Assets     []releaseAsset `json:"assets"`
+}
+
+type updateResult struct {
+	Current string
+	Latest  string
+	Updated bool
+}
+
+type updater struct {
+	client         *http.Client
+	latestURL      string
+	now            func() time.Time
+	lockPath       func() (string, error)
+	executablePath func() (string, error)
+	packageOwner   func(context.Context, string) string
+	goos           string
+	goarch         string
+	goarm          string
+}
+
+func newUpdater() *updater {
+	return &updater{
+		client:         newUpdateHTTPClient(),
+		latestURL:      latestReleaseURL,
+		now:            time.Now,
+		lockPath:       defaultUpdateLockPath,
+		executablePath: resolvedExecutablePath,
+		packageOwner:   installedPackageOwner,
+		goos:           runtime.GOOS,
+		goarch:         runtime.GOARCH,
+		goarm:          currentGOARM(),
+	}
+}
+
+func newUpdateHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: updateTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return errors.New("refusing update download redirect from HTTPS to an insecure URL")
+			}
+			if len(via) >= 10 {
+				return errors.New("too many update download redirects")
+			}
+			return nil
+		},
+	}
+}
+
+func defaultUpdateLockPath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "tailcat", "update.lock"), nil
+}
+
+func resolvedExecutablePath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("find running executable: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return "", fmt.Errorf("resolve running executable: %w", err)
+	}
+	return filepath.Clean(exe), nil
+}
+
+func currentGOARM() string {
+	if runtime.GOARCH != "arm" {
+		return ""
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range bi.Settings {
+			if setting.Key == "GOARM" {
+				return setting.Value
+			}
+		}
+	}
+	return os.Getenv("GOARM")
+}
+
+func updateMode() {
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+	check := fs.Bool("check", false, "check for an update without installing it")
+	fs.Parse(flag.Args()[1:]) // stripping off "update"
+	if len(fs.Args()) != 0 {
+		usage("tailcat update takes no positional arguments")
+	}
+
+	u := newUpdater()
+	if !*check {
+		releaseLock, acquired, err := u.acquireLock()
+		if err != nil {
+			fatalUpdate(err)
+		}
+		if !acquired {
+			fatalUpdate(errors.New("another tailcat update is already in progress"))
+		}
+		defer releaseLock()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
+	defer cancel()
+	result, err := u.run(ctx, versionString(), !*check)
+	if err != nil {
+		fatalUpdate(err)
+	}
+	printUpdateResult(result, *check)
+}
+
+func fatalUpdate(err error) {
+	fmt.Fprintf(os.Stderr, "tailcat update: %v\n", err)
+	os.Exit(1)
+}
+
+func printUpdateResult(result updateResult, checkOnly bool) {
+	switch {
+	case result.Updated:
+		fmt.Printf("updated tailcat from %s to %s; the new version will run on the next launch\n", result.Current, result.Latest)
+	case result.Current == result.Latest:
+		fmt.Printf("tailcat %s is up to date\n", result.Current)
+	case compareReleaseVersions(result.Current, result.Latest) > 0:
+		fmt.Printf("tailcat %s is newer than the latest release %s\n", result.Current, result.Latest)
+	case checkOnly:
+		fmt.Printf("tailcat %s is installed; %s is available\n", result.Current, result.Latest)
+	default:
+		fmt.Printf("tailcat %s was not updated\n", result.Current)
+	}
+}
+
+func (u *updater) run(ctx context.Context, current string, apply bool) (updateResult, error) {
+	if _, err := parseReleaseVersion(current); err != nil {
+		return updateResult{}, fmt.Errorf("cannot update development build with version %q", current)
+	}
+	rel, err := u.latestRelease(ctx, current)
+	if err != nil {
+		return updateResult{}, err
+	}
+	if _, err := parseReleaseVersion(rel.TagName); err != nil {
+		return updateResult{}, fmt.Errorf("latest release has invalid version %q", rel.TagName)
+	}
+	result := updateResult{Current: current, Latest: rel.TagName}
+	if compareReleaseVersions(current, rel.TagName) >= 0 {
+		return result, nil
+	}
+
+	archiveAsset, err := releaseArchiveAsset(rel, u.goos, u.goarch, u.goarm)
+	if err != nil {
+		return updateResult{}, err
+	}
+	if !apply {
+		return result, nil
+	}
+
+	exe, err := u.executablePath()
+	if err != nil {
+		return updateResult{}, err
+	}
+	if err := u.checkInstallMethod(ctx, exe); err != nil {
+		return updateResult{}, err
+	}
+	archiveName := archiveAsset.Name
+	checksumsAsset, err := uniqueReleaseAsset(rel.Assets, "checksums.txt")
+	if err != nil {
+		return updateResult{}, fmt.Errorf("release %s: %w", rel.TagName, err)
+	}
+
+	checksums, err := u.download(ctx, checksumsAsset, maxChecksums, current)
+	if err != nil {
+		return updateResult{}, fmt.Errorf("download checksums: %w", err)
+	}
+	wantHash, err := checksumForAsset(checksums, archiveName)
+	if err != nil {
+		return updateResult{}, err
+	}
+	archiveBytes, err := u.download(ctx, archiveAsset, maxReleaseAsset, current)
+	if err != nil {
+		return updateResult{}, fmt.Errorf("download %s: %w", archiveName, err)
+	}
+	gotHash := sha256.Sum256(archiveBytes)
+	if !bytes.Equal(gotHash[:], wantHash) {
+		return updateResult{}, fmt.Errorf("SHA-256 mismatch for %s: got %x, want %x", archiveName, gotHash, wantHash)
+	}
+	binary, err := extractReleaseBinary(archiveName, archiveBytes, u.goos)
+	if err != nil {
+		return updateResult{}, err
+	}
+	if err := replaceExecutable(exe, binary); err != nil {
+		return updateResult{}, err
+	}
+	result.Updated = true
+	return result, nil
+}
+
+func (u *updater) latestRelease(ctx context.Context, current string) (githubRelease, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.latestURL, nil)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "tailcat/"+current)
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("query latest release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return githubRelease{}, fmt.Errorf("query latest release: HTTP %s", resp.Status)
+	}
+	body, err := readAtMost(resp.Body, maxReleaseResponse)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("read latest release: %w", err)
+	}
+	var rel githubRelease
+	if err := json.Unmarshal(body, &rel); err != nil {
+		return githubRelease{}, fmt.Errorf("decode latest release: %w", err)
+	}
+	if rel.Draft || rel.Prerelease {
+		return githubRelease{}, fmt.Errorf("GitHub latest release %q is not a stable published release", rel.TagName)
+	}
+	return rel, nil
+}
+
+func (u *updater) download(ctx context.Context, asset releaseAsset, maxSize int64, current string) ([]byte, error) {
+	if asset.BrowserDownloadURL == "" {
+		return nil, fmt.Errorf("asset %q has no download URL", asset.Name)
+	}
+	assetURL, err := url.Parse(asset.BrowserDownloadURL)
+	if err != nil || assetURL.Scheme != "https" || assetURL.Host == "" {
+		return nil, fmt.Errorf("asset %q has invalid HTTPS download URL", asset.Name)
+	}
+	if asset.Size <= 0 || asset.Size > maxSize {
+		return nil, fmt.Errorf("asset %q has invalid size %d", asset.Name, asset.Size)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("User-Agent", "tailcat/"+current)
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %s", resp.Status)
+	}
+	b, err := readAtMost(resp.Body, maxSize)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) != asset.Size {
+		return nil, fmt.Errorf("asset %q size mismatch: got %d, want %d", asset.Name, len(b), asset.Size)
+	}
+	if err := verifyAssetDigest(asset, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func verifyAssetDigest(asset releaseAsset, b []byte) error {
+	if asset.Digest == "" {
+		return nil
+	}
+	algorithm, encoded, ok := strings.Cut(asset.Digest, ":")
+	if !ok || algorithm != "sha256" {
+		return fmt.Errorf("asset %q uses unsupported digest %q", asset.Name, asset.Digest)
+	}
+	want, err := hex.DecodeString(encoded)
+	if err != nil || len(want) != sha256.Size {
+		return fmt.Errorf("asset %q has invalid digest %q", asset.Name, asset.Digest)
+	}
+	got := sha256.Sum256(b)
+	if !bytes.Equal(got[:], want) {
+		return fmt.Errorf("GitHub digest mismatch for %s: got %x, want %x", asset.Name, got, want)
+	}
+	return nil
+}
+
+func readAtMost(r io.Reader, maxSize int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, maxSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > maxSize {
+		return nil, fmt.Errorf("response exceeds %d bytes", maxSize)
+	}
+	return b, nil
+}
+
+func uniqueReleaseAsset(assets []releaseAsset, name string) (releaseAsset, error) {
+	var found *releaseAsset
+	for _, asset := range assets {
+		if asset.Name == name {
+			if found != nil {
+				return releaseAsset{}, fmt.Errorf("contains duplicate asset %q", name)
+			}
+			assetCopy := asset
+			found = &assetCopy
+		}
+	}
+	if found == nil {
+		return releaseAsset{}, fmt.Errorf("has no asset %q", name)
+	}
+	return *found, nil
+}
+
+// releaseArchiveAsset follows the archives.name_template in .goreleaser.yaml.
+// It intentionally discovers the current GOOS/GOARCH in the release assets
+// rather than keeping a second platform allowlist that can drift from the
+// release matrix.
+func releaseArchiveAsset(rel githubRelease, goos, goarch, goarm string) (releaseAsset, error) {
+	base, err := releaseArchiveBase(rel.TagName, goos, goarch, goarm)
+	if err != nil {
+		return releaseAsset{}, err
+	}
+	validNames := map[string]bool{
+		base + ".tar.gz": true,
+		base + ".zip":    true,
+	}
+	var found *releaseAsset
+	for _, asset := range rel.Assets {
+		if !validNames[asset.Name] {
+			continue
+		}
+		if found != nil {
+			return releaseAsset{}, fmt.Errorf("release %s has multiple prebuilt archives for %s/%s", rel.TagName, goos, goarch)
+		}
+		assetCopy := asset
+		found = &assetCopy
+	}
+	if found == nil {
+		return releaseAsset{}, fmt.Errorf("release %s has no prebuilt archive for %s/%s", rel.TagName, goos, goarch)
+	}
+	return *found, nil
+}
+
+func releaseArchiveBase(version, goos, goarch, goarm string) (string, error) {
+	parsed, err := parseReleaseVersion(version)
+	if err != nil {
+		return "", err
+	}
+	if !validReleaseComponent(goos) || !validReleaseComponent(goarch) {
+		return "", fmt.Errorf("invalid release platform %q/%q", goos, goarch)
+	}
+	suffix := ""
+	if goarch == "arm" {
+		goarm, _, _ = strings.Cut(goarm, ",")
+		if goarm == "" || !validReleaseComponent(goarm) {
+			return "", fmt.Errorf("cannot determine the GOARM release variant")
+		}
+		suffix = "v" + goarm
+	}
+	return fmt.Sprintf("tailcat_%d.%d.%d_%s_%s%s", parsed[0], parsed[1], parsed[2], goos, goarch, suffix), nil
+}
+
+func validReleaseComponent(v string) bool {
+	if v == "" {
+		return false
+	}
+	for _, r := range v {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func parseReleaseVersion(v string) ([3]int, error) {
+	var ret [3]int
+	if !strings.HasPrefix(v, "v") {
+		return ret, fmt.Errorf("invalid release version %q", v)
+	}
+	parts := strings.Split(strings.TrimPrefix(v, "v"), ".")
+	if len(parts) != 3 {
+		return ret, fmt.Errorf("invalid release version %q", v)
+	}
+	for i, part := range parts {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
+			return ret, fmt.Errorf("invalid release version %q", v)
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return ret, fmt.Errorf("invalid release version %q", v)
+			}
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return ret, fmt.Errorf("invalid release version %q", v)
+		}
+		ret[i] = n
+	}
+	return ret, nil
+}
+
+func compareReleaseVersions(a, b string) int {
+	av, aErr := parseReleaseVersion(a)
+	bv, bErr := parseReleaseVersion(b)
+	if aErr != nil || bErr != nil {
+		return strings.Compare(a, b)
+	}
+	for i := range av {
+		if av[i] < bv[i] {
+			return -1
+		}
+		if av[i] > bv[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+func checksumForAsset(checksums []byte, assetName string) ([]byte, error) {
+	var found []byte
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || strings.TrimPrefix(fields[1], "*") != assetName {
+			continue
+		}
+		digest, err := hex.DecodeString(fields[0])
+		if err != nil || len(digest) != sha256.Size {
+			return nil, fmt.Errorf("invalid SHA-256 for %s in checksums.txt", assetName)
+		}
+		if found != nil {
+			return nil, fmt.Errorf("checksums.txt has duplicate entries for %s", assetName)
+		}
+		found = digest
+	}
+	if found == nil {
+		return nil, fmt.Errorf("checksums.txt has no SHA-256 for %s", assetName)
+	}
+	return found, nil
+}
+
+func extractReleaseBinary(archiveName string, archive []byte, goos string) ([]byte, error) {
+	binaryName := "tailcat"
+	if goos == "windows" {
+		binaryName += ".exe"
+	}
+	if strings.HasSuffix(archiveName, ".zip") {
+		return extractZIPBinary(archiveName, archive, binaryName)
+	}
+	if strings.HasSuffix(archiveName, ".tar.gz") {
+		return extractTarGzBinary(archiveName, archive, binaryName)
+	}
+	return nil, fmt.Errorf("unsupported release archive %q", archiveName)
+}
+
+func extractZIPBinary(archiveName string, archive []byte, binaryName string) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", archiveName, err)
+	}
+	var found []byte
+	var expanded uint64
+	if len(zr.File) > maxArchiveEntries {
+		return nil, fmt.Errorf("%s contains too many entries", archiveName)
+	}
+	for _, f := range zr.File {
+		if f.UncompressedSize64 > uint64(maxExpandedArchive)-expanded {
+			return nil, fmt.Errorf("expanded %s exceeds %d bytes", archiveName, maxExpandedArchive)
+		}
+		expanded += f.UncompressedSize64
+		if path.Clean(f.Name) != binaryName {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("%s contains duplicate %s entries", archiveName, binaryName)
+		}
+		if !f.Mode().IsRegular() || f.UncompressedSize64 > maxBinary {
+			return nil, fmt.Errorf("invalid %s entry in %s", binaryName, archiveName)
+		}
+		r, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		found, err = readAtMost(r, maxBinary)
+		closeErr := r.Close()
+		if err != nil {
+			return nil, err
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("%s contains no %s", archiveName, binaryName)
+	}
+	return found, nil
+}
+
+func extractTarGzBinary(archiveName string, archive []byte, binaryName string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", archiveName, err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var found []byte
+	var expanded int64
+	entries := 0
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", archiveName, err)
+		}
+		entries++
+		if entries > maxArchiveEntries {
+			return nil, fmt.Errorf("%s contains too many entries", archiveName)
+		}
+		if hdr.Size < 0 || hdr.Size > maxExpandedArchive-expanded {
+			return nil, fmt.Errorf("expanded %s exceeds %d bytes", archiveName, maxExpandedArchive)
+		}
+		expanded += hdr.Size
+		if path.Clean(hdr.Name) != binaryName {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("%s contains duplicate %s entries", archiveName, binaryName)
+		}
+		if hdr.Typeflag != tar.TypeReg || hdr.Size < 0 || hdr.Size > maxBinary {
+			return nil, fmt.Errorf("invalid %s entry in %s", binaryName, archiveName)
+		}
+		found, err = readAtMost(tr, maxBinary)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if found == nil {
+		return nil, fmt.Errorf("%s contains no %s", archiveName, binaryName)
+	}
+	return found, nil
+}
+
+func replaceExecutable(exe string, binary []byte) error {
+	fi, err := os.Stat(exe)
+	if err != nil {
+		return fmt.Errorf("stat current executable: %w", err)
+	}
+	dir := filepath.Dir(exe)
+	staged, err := os.CreateTemp(dir, ".tailcat-update-*")
+	if err != nil {
+		return fmt.Errorf("create update beside %s: %w", exe, err)
+	}
+	stagedName := staged.Name()
+	defer func() {
+		staged.Close()
+		os.Remove(stagedName)
+	}()
+	if _, err := staged.Write(binary); err != nil {
+		return fmt.Errorf("write staged update: %w", err)
+	}
+	if err := staged.Chmod(fi.Mode().Perm()); err != nil {
+		return fmt.Errorf("set staged update permissions: %w", err)
+	}
+	if err := staged.Sync(); err != nil {
+		return fmt.Errorf("sync staged update: %w", err)
+	}
+	if err := staged.Close(); err != nil {
+		return fmt.Errorf("close staged update: %w", err)
+	}
+
+	return installStagedExecutable(stagedName, exe)
+}
+
+func updateBackupPath(exe string) string {
+	return exe + ".tailcat-update-old"
+}
+
+func (u *updater) acquireLock() (release func(), acquired bool, err error) {
+	lockPath, err := u.lockPath()
+	if err != nil {
+		return nil, false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
+		return nil, false, err
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err == nil {
+			if _, err := fmt.Fprintf(f, "%d\n", os.Getpid()); err != nil {
+				f.Close()
+				os.Remove(lockPath)
+				return nil, false, err
+			}
+			if err := f.Close(); err != nil {
+				os.Remove(lockPath)
+				return nil, false, err
+			}
+			return func() { os.Remove(lockPath) }, true, nil
+		}
+		if !os.IsExist(err) {
+			return nil, false, err
+		}
+		fi, statErr := os.Stat(lockPath)
+		if statErr != nil || u.now().Sub(fi.ModTime()) <= 10*time.Minute {
+			return func() {}, false, nil
+		}
+		if err := os.Remove(lockPath); err != nil {
+			return nil, false, err
+		}
+	}
+	return func() {}, false, nil
+}
+
+func (u *updater) checkInstallMethod(ctx context.Context, exe string) error {
+	clean := filepath.ToSlash(exe)
+	if strings.HasPrefix(clean, "/nix/store/") {
+		return errors.New("this executable is managed by Nix; update it with nix profile upgrade")
+	}
+	if owner := u.packageOwner(ctx, exe); owner != "" {
+		return fmt.Errorf("this executable is managed by %s; update it with that package manager", owner)
+	}
+	if owner := pathPackageOwner(u.goos, exe); owner != "" {
+		return fmt.Errorf("this executable is managed by %s; update it with that package manager", owner)
+	}
+	if isSystemPackageExecutablePath(u.goos, exe) {
+		return errors.New("this executable is in a system package directory; update it with the package manager or install a standalone binary elsewhere")
+	}
+	probe, err := os.CreateTemp(filepath.Dir(exe), ".tailcat-update-permission-*")
+	if err != nil {
+		return fmt.Errorf("the executable directory is not writable: %w", err)
+	}
+	probeName := probe.Name()
+	if err := probe.Close(); err != nil {
+		os.Remove(probeName)
+		return fmt.Errorf("close update permission probe: %w", err)
+	}
+	if err := os.Remove(probeName); err != nil {
+		return fmt.Errorf("remove update permission probe: %w", err)
+	}
+	return nil
+}
+
+func pathPackageOwner(goos, exe string) string {
+	clean := path.Clean(filepath.ToSlash(exe))
+	if (goos == "darwin" || goos == "linux") &&
+		(strings.Contains(clean, "/Cellar/tailcat/") || strings.Contains(clean, "/Caskroom/tailcat/")) {
+		return "Homebrew"
+	}
+	if goos == "darwin" && (clean == "/opt/local" || strings.HasPrefix(clean, "/opt/local/")) {
+		return "MacPorts"
+	}
+	if goos == "windows" {
+		clean = normalizeWindowsPath(exe)
+		switch {
+		case strings.Contains(clean, "/microsoft/winget/packages/"), strings.Contains(clean, "/winget/packages/"),
+			strings.Contains(clean, "/microsoft/winget/links/"), strings.Contains(clean, "/winget/links/"):
+			return "WinGet"
+		case strings.Contains(clean, "/windowsapps/"):
+			return "Microsoft Store/MSIX"
+		case strings.Contains(clean, "/scoop/apps/tailcat/"):
+			return "Scoop"
+		case strings.Contains(clean, "/chocolatey/lib/tailcat/"):
+			return "Chocolatey"
+		case strings.Contains(clean, "/program files/"), strings.Contains(clean, "/program files (x86)/"):
+			return "the Windows installer"
+		case strings.Contains(clean, ":/windows/"):
+			return "Windows"
+		}
+	}
+	return ""
+}
+
+func isSystemPackageExecutablePath(goos, exe string) bool {
+	if goos != "linux" && goos != "darwin" {
+		return false
+	}
+	switch path.Dir(path.Clean(filepath.ToSlash(exe))) {
+	case "/usr/bin", "/usr/sbin", "/bin", "/sbin":
+		return true
+	default:
+		return false
+	}
+}
+
+func installedPackageOwner(ctx context.Context, exe string) string {
+	if runtime.GOOS == "windows" {
+		return windowsPackageOwner(exe)
+	}
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+	for _, check := range linuxPackageOwnershipChecks(exe) {
+		checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		err := exec.CommandContext(checkCtx, check.name, check.args...).Run()
+		cancel()
+		if err == nil {
+			return check.kind
+		}
+	}
+	return ""
+}
+
+type packageOwnershipCheck struct {
+	name string
+	args []string
+	kind string
+}
+
+func linuxPackageOwnershipChecks(exe string) []packageOwnershipCheck {
+	return []packageOwnershipCheck{
+		{"dpkg-query", []string{"--search", exe}, "dpkg"},
+		{"rpm", []string{"-qf", exe}, "RPM"},
+		{"pacman", []string{"-Qo", exe}, "pacman"},
+	}
+}

--- a/cmd/tailcat/update.go
+++ b/cmd/tailcat/update.go
@@ -144,20 +144,15 @@ func updateMode() {
 	}
 
 	u := newUpdater()
-	if !*check {
-		releaseLock, acquired, err := u.acquireLock()
-		if err != nil {
-			fatalUpdate(err)
-		}
-		if !acquired {
-			fatalUpdate(errors.New("another tailcat update is already in progress"))
-		}
-		defer releaseLock()
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
 	defer cancel()
-	result, err := u.run(ctx, versionString(), !*check)
+	var result updateResult
+	var err error
+	if *check {
+		result, err = u.run(ctx, versionString(), false)
+	} else {
+		result, err = u.runWithLock(ctx, versionString())
+	}
 	if err != nil {
 		fatalUpdate(err)
 	}
@@ -167,6 +162,18 @@ func updateMode() {
 func fatalUpdate(err error) {
 	fmt.Fprintf(os.Stderr, "tailcat update: %v\n", err)
 	os.Exit(1)
+}
+
+func (u *updater) runWithLock(ctx context.Context, current string) (updateResult, error) {
+	releaseLock, acquired, err := u.acquireLock()
+	if err != nil {
+		return updateResult{}, err
+	}
+	if !acquired {
+		return updateResult{}, errors.New("another tailcat update is already in progress")
+	}
+	defer releaseLock()
+	return u.run(ctx, current, true)
 }
 
 func printUpdateResult(result updateResult, checkOnly bool) {

--- a/cmd/tailcat/update_install_unix.go
+++ b/cmd/tailcat/update_install_unix.go
@@ -1,0 +1,20 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func installStagedExecutable(staged, exe string) error {
+	if err := os.Rename(staged, exe); err != nil {
+		return fmt.Errorf("install update atomically: %w", err)
+	}
+	return nil
+}
+
+func cleanupUpdateBackup() {}

--- a/cmd/tailcat/update_install_windows.go
+++ b/cmd/tailcat/update_install_windows.go
@@ -1,0 +1,39 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func installStagedExecutable(staged, exe string) error {
+	backup := updateBackupPath(exe)
+	if err := os.Remove(backup); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove previous update backup: %w", err)
+	}
+	if err := os.Rename(exe, backup); err != nil {
+		return fmt.Errorf("move current executable aside: %w", err)
+	}
+	if err := os.Rename(staged, exe); err != nil {
+		rollbackErr := os.Rename(backup, exe)
+		if rollbackErr != nil {
+			return fmt.Errorf("install update: %v; rollback also failed: %w", err, rollbackErr)
+		}
+		return fmt.Errorf("install update: %w (rolled back)", err)
+	}
+	// Removing the old executable fails while the current process is still
+	// running from it. A later invocation cleans it up.
+	_ = os.Remove(backup)
+	return nil
+}
+
+func cleanupUpdateBackup() {
+	exe, err := resolvedExecutablePath()
+	if err == nil {
+		_ = os.Remove(updateBackupPath(exe))
+	}
+}

--- a/cmd/tailcat/update_package.go
+++ b/cmd/tailcat/update_package.go
@@ -1,0 +1,84 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type windowsPackageRecord struct {
+	displayName             string
+	installLocation         string
+	displayIcon             string
+	portableTargetFullPath  string
+	winGetInstallerType     string
+	winGetPackageIdentifier string
+	uninstallString         string
+}
+
+type windowsManagedRoot struct {
+	owner string
+	root  string
+	rel   string
+}
+
+func windowsManagedRootOwner(exe string, roots []windowsManagedRoot) string {
+	for _, root := range roots {
+		if root.root != "" && windowsPathWithin(exe, root.root+"/"+root.rel) {
+			return root.owner
+		}
+	}
+	return ""
+}
+
+func windowsPackageRecordOwner(exe string, records []windowsPackageRecord) string {
+	exe = normalizeWindowsPath(exe)
+	for _, record := range records {
+		owner := "the Windows installer"
+		if record.winGetInstallerType != "" || record.winGetPackageIdentifier != "" ||
+			strings.Contains(strings.ToLower(record.uninstallString), "winget") {
+			owner = "WinGet"
+		}
+		if sameWindowsPath(exe, record.portableTargetFullPath) || sameWindowsPath(exe, trimDisplayIconIndex(record.displayIcon)) {
+			return owner
+		}
+		identity := strings.ToLower(record.displayName + " " + record.winGetPackageIdentifier)
+		if strings.Contains(identity, "tailcat") && windowsPathWithin(exe, record.installLocation) {
+			return owner
+		}
+	}
+	return ""
+}
+
+func normalizeWindowsPath(v string) string {
+	v = strings.TrimSpace(strings.Trim(v, "\""))
+	v = strings.ReplaceAll(v, "\\", "/")
+	return strings.ToLower(path.Clean(filepath.ToSlash(v)))
+}
+
+func sameWindowsPath(a, b string) bool {
+	return b != "" && normalizeWindowsPath(a) == normalizeWindowsPath(b)
+}
+
+func windowsPathWithin(file, dir string) bool {
+	if dir == "" {
+		return false
+	}
+	file = normalizeWindowsPath(file)
+	dir = strings.TrimSuffix(normalizeWindowsPath(dir), "/")
+	return file == dir || strings.HasPrefix(file, dir+"/")
+}
+
+func trimDisplayIconIndex(v string) string {
+	v = strings.TrimSpace(v)
+	if comma := strings.LastIndexByte(v, ','); comma >= 0 {
+		suffix := strings.TrimSpace(v[comma+1:])
+		if suffix != "" && strings.Trim(suffix, "-0123456789") == "" {
+			v = strings.TrimSpace(v[:comma])
+		}
+	}
+	return strings.Trim(v, "\"")
+}

--- a/cmd/tailcat/update_package_nonwindows.go
+++ b/cmd/tailcat/update_package_nonwindows.go
@@ -1,0 +1,8 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build !windows
+
+package main
+
+func windowsPackageOwner(string) string { return "" }

--- a/cmd/tailcat/update_package_windows.go
+++ b/cmd/tailcat/update_package_windows.go
@@ -1,0 +1,86 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const windowsUninstallKey = `Software\Microsoft\Windows\CurrentVersion\Uninstall`
+
+type windowsRegistryRoot struct {
+	key  registry.Key
+	path string
+}
+
+func windowsPackageOwner(exe string) string {
+	if owner := windowsManagedRootOwner(exe, []windowsManagedRoot{
+		{"Scoop", os.Getenv("SCOOP"), "apps/tailcat"},
+		{"Scoop", os.Getenv("SCOOP_GLOBAL"), "apps/tailcat"},
+		{"Chocolatey", os.Getenv("ChocolateyInstall"), "lib/tailcat"},
+	}); owner != "" {
+		return owner
+	}
+	roots := []windowsRegistryRoot{
+		{registry.CURRENT_USER, windowsUninstallKey},
+		{registry.CURRENT_USER, `Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`},
+		{registry.LOCAL_MACHINE, windowsUninstallKey},
+		{registry.LOCAL_MACHINE, `Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`},
+	}
+	var records []windowsPackageRecord
+	for _, root := range roots {
+		records = append(records, readWindowsPackageRecords(root)...)
+	}
+	return windowsPackageRecordOwner(exe, records)
+}
+
+func readWindowsPackageRecords(root windowsRegistryRoot) []windowsPackageRecord {
+	k, err := registry.OpenKey(root.key, root.path, registry.READ)
+	if err != nil {
+		return nil
+	}
+	defer k.Close()
+	names, err := k.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil
+	}
+	records := make([]windowsPackageRecord, 0, len(names))
+	for _, name := range names {
+		subkey, err := registry.OpenKey(k, name, registry.READ)
+		if err != nil {
+			continue
+		}
+		record := windowsPackageRecord{
+			displayName:             registryString(subkey, "DisplayName"),
+			installLocation:         registryString(subkey, "InstallLocation"),
+			displayIcon:             registryString(subkey, "DisplayIcon"),
+			portableTargetFullPath:  registryString(subkey, "PortableTargetFullPath"),
+			winGetInstallerType:     registryString(subkey, "WinGetInstallerType"),
+			winGetPackageIdentifier: registryString(subkey, "WinGetPackageIdentifier"),
+			uninstallString:         registryString(subkey, "UninstallString"),
+		}
+		subkey.Close()
+		if record.displayName != "" || record.portableTargetFullPath != "" || record.installLocation != "" {
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+func registryString(k registry.Key, name string) string {
+	value, valueType, err := k.GetStringValue(name)
+	if err != nil {
+		return ""
+	}
+	if valueType == registry.EXPAND_SZ {
+		if expanded, err := registry.ExpandString(value); err == nil {
+			return expanded
+		}
+	}
+	return value
+}

--- a/cmd/tailcat/update_test.go
+++ b/cmd/tailcat/update_test.go
@@ -78,6 +78,28 @@ func TestCompareReleaseVersions(t *testing.T) {
 	}
 }
 
+func TestRunWithLockReleasesLockOnError(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "update.lock")
+	u := &updater{
+		lockPath: func() (string, error) { return lockPath, nil },
+	}
+	if _, err := u.runWithLock(context.Background(), "(devel)"); err == nil {
+		t.Fatal("development build unexpectedly updated")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("update lock remains after error: %v", err)
+	}
+
+	releaseLock, acquired, err := u.acquireLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acquired {
+		t.Fatal("could not reacquire update lock after error")
+	}
+	releaseLock()
+}
+
 func TestChecksumForAsset(t *testing.T) {
 	want := sha256.Sum256([]byte("archive"))
 	checksums := fmt.Appendf(nil, "%x  other.zip\n%x *tailcat.zip\n", sha256.Sum256(nil), want)

--- a/cmd/tailcat/update_test.go
+++ b/cmd/tailcat/update_test.go
@@ -1,0 +1,458 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestReleaseArchiveAsset(t *testing.T) {
+	tests := []struct {
+		name, version, goos, goarch, goarm, want string
+	}{
+		{"linux-amd64", "v0.2.0", "linux", "amd64", "", "tailcat_0.2.0_linux_amd64.tar.gz"},
+		{"linux-arm64", "v0.2.0", "linux", "arm64", "", "tailcat_0.2.0_linux_arm64.tar.gz"},
+		{"linux-armv7", "v0.2.0", "linux", "arm", "7", "tailcat_0.2.0_linux_armv7.tar.gz"},
+		{"linux-armv6-hardfloat", "v1.12.3", "linux", "arm", "6,hardfloat", "tailcat_1.12.3_linux_armv6.tar.gz"},
+		{"windows-amd64", "v1.2.3", "windows", "amd64", "", "tailcat_1.2.3_windows_amd64.zip"},
+		{"windows-arm64", "v1.2.3", "windows", "arm64", "", "tailcat_1.2.3_windows_arm64.zip"},
+		{"future-darwin-amd64", "v1.2.3", "darwin", "amd64", "", "tailcat_1.2.3_darwin_amd64.tar.gz"},
+		{"future-darwin-arm64", "v1.2.3", "darwin", "arm64", "", "tailcat_1.2.3_darwin_arm64.tar.gz"},
+		{"future-freebsd-riscv64", "v1.2.3", "freebsd", "riscv64", "", "tailcat_1.2.3_freebsd_riscv64.tar.gz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rel := githubRelease{TagName: tt.version, Assets: []releaseAsset{{Name: "checksums.txt"}, {Name: tt.want}}}
+			got, err := releaseArchiveAsset(rel, tt.goos, tt.goarch, tt.goarm)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Name != tt.want {
+				t.Fatalf("releaseArchiveAsset = %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+
+	missing := githubRelease{TagName: "v1.2.3"}
+	if _, err := releaseArchiveAsset(missing, "darwin", "arm64", ""); err == nil {
+		t.Fatal("missing platform archive unexpectedly succeeded")
+	}
+	ambiguous := githubRelease{TagName: "v1.2.3", Assets: []releaseAsset{
+		{Name: "tailcat_1.2.3_darwin_arm64.tar.gz"},
+		{Name: "tailcat_1.2.3_darwin_arm64.zip"},
+	}}
+	if _, err := releaseArchiveAsset(ambiguous, "darwin", "arm64", ""); err == nil {
+		t.Fatal("ambiguous platform archives unexpectedly succeeded")
+	}
+	if _, err := releaseArchiveBase("v1.2.3", "../darwin", "arm64", ""); err == nil {
+		t.Fatal("unsafe platform component unexpectedly succeeded")
+	}
+}
+
+func TestCompareReleaseVersions(t *testing.T) {
+	for _, tt := range []struct {
+		a, b string
+		want int
+	}{
+		{"v0.2.0", "v0.2.0", 0},
+		{"v0.2.0", "v0.10.0", -1},
+		{"v2.0.0", "v1.99.99", 1},
+	} {
+		if got := compareReleaseVersions(tt.a, tt.b); got != tt.want {
+			t.Errorf("compareReleaseVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestChecksumForAsset(t *testing.T) {
+	want := sha256.Sum256([]byte("archive"))
+	checksums := fmt.Appendf(nil, "%x  other.zip\n%x *tailcat.zip\n", sha256.Sum256(nil), want)
+	got, err := checksumForAsset(checksums, "tailcat.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("checksum = %x, want %x", got, want)
+	}
+	if _, err := checksumForAsset(checksums, "missing.zip"); err == nil {
+		t.Fatal("missing checksum unexpectedly succeeded")
+	}
+	duplicate := append(append([]byte(nil), checksums...), fmt.Appendf(nil, "%x  tailcat.zip\n", want)...)
+	if _, err := checksumForAsset(duplicate, "tailcat.zip"); err == nil {
+		t.Fatal("duplicate checksum unexpectedly succeeded")
+	}
+}
+
+func TestUniqueReleaseAssetRejectsDuplicates(t *testing.T) {
+	assets := []releaseAsset{{Name: "tailcat.zip"}, {Name: "tailcat.zip"}}
+	if _, err := uniqueReleaseAsset(assets, "tailcat.zip"); err == nil {
+		t.Fatal("duplicate release asset unexpectedly succeeded")
+	}
+}
+
+func TestExtractReleaseBinary(t *testing.T) {
+	const want = "new tailcat binary"
+	zipBytes := testZIP(t, "tailcat.exe", []byte(want))
+	got, err := extractReleaseBinary("tailcat_1.0.0_windows_amd64.zip", zipBytes, "windows")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("ZIP binary = %q, want %q", got, want)
+	}
+
+	tarBytes := testTarGz(t, "tailcat", []byte(want))
+	got, err = extractReleaseBinary("tailcat_1.0.0_linux_amd64.tar.gz", tarBytes, "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("tar binary = %q, want %q", got, want)
+	}
+
+	nested := testZIP(t, "bin/tailcat.exe", []byte(want))
+	if _, err := extractReleaseBinary("tailcat.zip", nested, "windows"); err == nil {
+		t.Fatal("nested executable unexpectedly accepted")
+	}
+}
+
+func TestUpdaterRun(t *testing.T) {
+	const (
+		currentVersion = "v0.1.0"
+		latestVersion  = "v0.2.0"
+		newBinary      = "new tailcat binary"
+	)
+	tests := []struct {
+		name, goos, goarch, goarm, archiveName, binaryName string
+	}{
+		{"linux-amd64", "linux", "amd64", "", "tailcat_0.2.0_linux_amd64.tar.gz", "tailcat"},
+		{"linux-arm64", "linux", "arm64", "", "tailcat_0.2.0_linux_arm64.tar.gz", "tailcat"},
+		{"linux-armv7", "linux", "arm", "7", "tailcat_0.2.0_linux_armv7.tar.gz", "tailcat"},
+		{"windows-amd64", "windows", "amd64", "", "tailcat_0.2.0_windows_amd64.zip", "tailcat.exe"},
+		{"windows-arm64", "windows", "arm64", "", "tailcat_0.2.0_windows_arm64.zip", "tailcat.exe"},
+		{"darwin-amd64", "darwin", "amd64", "", "tailcat_0.2.0_darwin_amd64.tar.gz", "tailcat"},
+		{"darwin-arm64", "darwin", "arm64", "", "tailcat_0.2.0_darwin_arm64.tar.gz", "tailcat"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var archive []byte
+			if tt.goos == "windows" {
+				archive = testZIP(t, tt.binaryName, []byte(newBinary))
+			} else {
+				archive = testTarGz(t, tt.binaryName, []byte(newBinary))
+			}
+			digest := sha256.Sum256(archive)
+			checksums := fmt.Appendf(nil, "%x  %s\n", digest, tt.archiveName)
+
+			var server *httptest.Server
+			server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/latest":
+					json.NewEncoder(w).Encode(githubRelease{
+						TagName: latestVersion,
+						Assets: []releaseAsset{
+							{Name: tt.archiveName, BrowserDownloadURL: server.URL + "/archive", Size: int64(len(archive))},
+							{Name: "checksums.txt", BrowserDownloadURL: server.URL + "/checksums", Size: int64(len(checksums))},
+						},
+					})
+				case "/archive":
+					w.Write(archive)
+				case "/checksums":
+					w.Write(checksums)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			target := filepath.Join(t.TempDir(), tt.binaryName)
+			if err := os.WriteFile(target, []byte("old tailcat binary"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			u := &updater{
+				client:         server.Client(),
+				latestURL:      server.URL + "/latest",
+				executablePath: func() (string, error) { return target, nil },
+				packageOwner:   func(context.Context, string) string { return "" },
+				goos:           tt.goos,
+				goarch:         tt.goarch,
+				goarm:          tt.goarm,
+			}
+			result, err := u.run(context.Background(), currentVersion, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.Updated || result.Current != currentVersion || result.Latest != latestVersion {
+				t.Fatalf("result = %+v", result)
+			}
+			got, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != newBinary {
+				t.Fatalf("installed binary = %q, want %q", got, newBinary)
+			}
+			if _, err := os.Stat(updateBackupPath(target)); !os.IsNotExist(err) {
+				t.Fatalf("backup still exists: %v", err)
+			}
+		})
+	}
+}
+
+func TestLinuxPackageOwnershipChecks(t *testing.T) {
+	const exe = "/usr/bin/tailcat"
+	checks := linuxPackageOwnershipChecks(exe)
+	want := []packageOwnershipCheck{
+		{"dpkg-query", []string{"--search", exe}, "dpkg"},
+		{"rpm", []string{"-qf", exe}, "RPM"},
+		{"pacman", []string{"-Qo", exe}, "pacman"},
+	}
+	if len(checks) != len(want) {
+		t.Fatalf("got %d ownership checks, want %d", len(checks), len(want))
+	}
+	for i := range want {
+		if checks[i].name != want[i].name || checks[i].kind != want[i].kind || !slices.Equal(checks[i].args, want[i].args) {
+			t.Errorf("check %d = %+v, want %+v", i, checks[i], want[i])
+		}
+	}
+}
+
+func TestManagedInstallPaths(t *testing.T) {
+	for _, tt := range []struct {
+		goos, exe, want string
+	}{
+		{"darwin", "/opt/homebrew/Cellar/tailcat/1.0.0/bin/tailcat", "Homebrew"},
+		{"darwin", "/usr/local/Cellar/tailcat/1.0.0/bin/tailcat", "Homebrew"},
+		{"linux", "/home/linuxbrew/.linuxbrew/Cellar/tailcat/1.0.0/bin/tailcat", "Homebrew"},
+		{"darwin", "/opt/local/bin/tailcat", "MacPorts"},
+		{"darwin", "/Users/me/bin/tailcat", ""},
+		{"windows", `C:\Users\me\AppData\Local\Microsoft\WinGet\Packages\Tailscale.Tailcat\tailcat.exe`, "WinGet"},
+		{"windows", `C:\Program Files\WindowsApps\Tailscale.Tailcat\tailcat.exe`, "Microsoft Store/MSIX"},
+		{"windows", `C:\Users\me\scoop\apps\tailcat\current\tailcat.exe`, "Scoop"},
+		{"windows", `C:\ProgramData\chocolatey\lib\tailcat\tools\tailcat.exe`, "Chocolatey"},
+		{"windows", `C:\Program Files\Tailcat\tailcat.exe`, "the Windows installer"},
+		{"windows", `C:\Windows\System32\tailcat.exe`, "Windows"},
+		{"windows", `C:\Tools\tailcat.exe`, ""},
+	} {
+		if got := pathPackageOwner(tt.goos, tt.exe); got != tt.want {
+			t.Errorf("pathPackageOwner(%q, %q) = %q, want %q", tt.goos, tt.exe, got, tt.want)
+		}
+	}
+}
+
+func TestWindowsManagedRootOwner(t *testing.T) {
+	roots := []windowsManagedRoot{
+		{"Scoop", `D:\CustomScoop`, "apps/tailcat"},
+		{"Chocolatey", `E:\Packages`, "lib/tailcat"},
+	}
+	for _, tt := range []struct {
+		exe, want string
+	}{
+		{`D:\CustomScoop\apps\tailcat\current\tailcat.exe`, "Scoop"},
+		{`E:\Packages\lib\tailcat\tools\tailcat.exe`, "Chocolatey"},
+		{`D:\CustomScoop\apps\other\tailcat.exe`, ""},
+	} {
+		if got := windowsManagedRootOwner(tt.exe, roots); got != tt.want {
+			t.Errorf("windowsManagedRootOwner(%q) = %q, want %q", tt.exe, got, tt.want)
+		}
+	}
+}
+
+func TestWindowsPackageRecordOwner(t *testing.T) {
+	for _, tt := range []struct {
+		name, exe, want string
+		records         []windowsPackageRecord
+	}{
+		{
+			name: "winget portable target in custom root",
+			exe:  `D:\PortableApps\Tailcat\tailcat.exe`,
+			want: "WinGet",
+			records: []windowsPackageRecord{{
+				portableTargetFullPath:  `D:\PortableApps\Tailcat\tailcat.exe`,
+				winGetPackageIdentifier: "Tailscale.Tailcat",
+			}},
+		},
+		{
+			name: "winget custom install directory",
+			exe:  `D:\PortableApps\Tailcat\bin\tailcat.exe`,
+			want: "WinGet",
+			records: []windowsPackageRecord{{
+				displayName:             "Tailcat",
+				installLocation:         `D:\PortableApps\Tailcat`,
+				winGetPackageIdentifier: "Tailscale.Tailcat",
+			}},
+		},
+		{
+			name: "registered installer directory",
+			exe:  `C:\Users\me\AppData\Local\Programs\Tailcat\tailcat.exe`,
+			want: "the Windows installer",
+			records: []windowsPackageRecord{{
+				displayName:     "Tailcat",
+				installLocation: `C:\Users\me\AppData\Local\Programs\Tailcat`,
+			}},
+		},
+		{
+			name: "registered display icon",
+			exe:  `C:\Apps\Tailcat\tailcat.exe`,
+			want: "the Windows installer",
+			records: []windowsPackageRecord{{
+				displayIcon: `"C:\Apps\Tailcat\tailcat.exe",0`,
+			}},
+		},
+		{
+			name: "unrelated broad install directory",
+			exe:  `C:\Users\me\bin\tailcat.exe`,
+			records: []windowsPackageRecord{{
+				displayName:     "Unrelated application",
+				installLocation: `C:\Users\me`,
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := windowsPackageRecordOwner(tt.exe, tt.records); got != tt.want {
+				t.Fatalf("windowsPackageRecordOwner() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSystemPackageExecutablePath(t *testing.T) {
+	for _, tt := range []struct {
+		goos, exe string
+		want      bool
+	}{
+		{"linux", "/usr/bin/tailcat", true},
+		{"linux", "/usr/sbin/tailcat", true},
+		{"linux", "/bin/tailcat", true},
+		{"linux", "/sbin/tailcat", true},
+		{"linux", "/usr/local/bin/tailcat", false},
+		{"linux", "/home/user/bin/tailcat", false},
+		{"darwin", "/usr/bin/tailcat", true},
+		{"darwin", "/opt/homebrew/bin/tailcat", false},
+		{"windows", "/usr/bin/tailcat", false},
+	} {
+		if got := isSystemPackageExecutablePath(tt.goos, tt.exe); got != tt.want {
+			t.Errorf("isSystemPackageExecutablePath(%q, %q) = %v, want %v", tt.goos, tt.exe, got, tt.want)
+		}
+	}
+}
+
+func TestDownloadRejectsInsecureURLAndSizeMismatch(t *testing.T) {
+	u := &updater{client: http.DefaultClient}
+	if _, err := u.download(context.Background(), releaseAsset{
+		Name: "tailcat.zip", BrowserDownloadURL: "http://example.com/tailcat.zip", Size: 1,
+	}, 10, "v0.1.0"); err == nil {
+		t.Fatal("insecure asset URL unexpectedly succeeded")
+	}
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("abc"))
+	}))
+	defer server.Close()
+	u.client = server.Client()
+	if _, err := u.download(context.Background(), releaseAsset{
+		Name: "tailcat.zip", BrowserDownloadURL: server.URL, Size: 4,
+	}, 10, "v0.1.0"); err == nil {
+		t.Fatal("asset size mismatch unexpectedly succeeded")
+	}
+}
+
+func TestUpdaterRejectsBadChecksum(t *testing.T) {
+	const archiveName = "tailcat_0.2.0_windows_amd64.zip"
+	archive := testZIP(t, "tailcat.exe", []byte("new"))
+	checksums := []byte(fmt.Sprintf("%064x  %s\n", 1, archiveName))
+
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest" {
+			json.NewEncoder(w).Encode(githubRelease{
+				TagName: "v0.2.0",
+				Assets: []releaseAsset{
+					{Name: archiveName, BrowserDownloadURL: server.URL + "/archive", Size: int64(len(archive))},
+					{Name: "checksums.txt", BrowserDownloadURL: server.URL + "/checksums", Size: int64(len(checksums))},
+				},
+			})
+			return
+		}
+		if r.URL.Path == "/archive" {
+			w.Write(archive)
+			return
+		}
+		w.Write(checksums)
+	}))
+	defer server.Close()
+
+	target := filepath.Join(t.TempDir(), "tailcat.exe")
+	if err := os.WriteFile(target, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	u := &updater{
+		client:         server.Client(),
+		latestURL:      server.URL + "/latest",
+		executablePath: func() (string, error) { return target, nil },
+		packageOwner:   func(context.Context, string) string { return "" },
+		goos:           "windows",
+		goarch:         "amd64",
+	}
+	if _, err := u.run(context.Background(), "v0.1.0", true); err == nil {
+		t.Fatal("bad checksum unexpectedly succeeded")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("target changed after rejected update: %q", got)
+	}
+}
+
+func testZIP(t *testing.T, name string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func testTarGz(t *testing.T, name string, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0755, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary

- add explicit `tailcat update --check` and `tailcat update` commands
- discover the matching prebuilt asset from the current GitHub Release matrix and verify it against `checksums.txt`
- replace standalone binaries safely while deferring package-managed installations to their package manager

This is deliberately manual-only: there is no startup check, background update, persistent update setting, or automatic restart.

## Safety

- require HTTPS and reject downgrade redirects
- enforce API-reported and local download and extraction size limits
- verify GitHub asset digests when present and require the release SHA-256 from `checksums.txt`
- reject duplicate assets, duplicate checksum entries, and unsafe archives
- use atomic replacement on Unix and rollback-capable replacement on Windows
- avoid in-place updates for Nix, dpkg/RPM/pacman, Homebrew/MacPorts, WinGet/Scoop/Chocolatey, and protected installer/system locations

## Tests

- focused updater unit and integration tests
- `go test ./... -run '^$'`
- `go vet ./cmd/tailcat`
- cross-builds for Linux amd64/arm64/armv7, Windows amd64/arm64, and Darwin amd64/arm64
- real Windows v0.1.0 -> v0.2.0 update against the official GitHub Release assets

Full Windows `go test ./...` still encounters the repository's existing executable-path issue in `TestPipeMode` and `TestSOCKSClientKey`: the tests build `tailcat.exe` but invoke `tailcat`. The updater tests, full compile check, vet, and release-target cross-builds pass.
