### PR TITLE
.github/workflows: run tests on macOS and Windows too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/cmd/tailcat/pipe_test.go
+++ b/cmd/tailcat/pipe_test.go
@@ -12,12 +12,26 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"tailscale.com/tstest/integration"
 )
+
+// buildTailcat builds the tailcat binary into a temp dir and returns
+// its path, with the ".exe" suffix that Windows requires to exec it.
+func buildTailcat(t *testing.T) string {
+	bin := filepath.Join(t.TempDir(), "tailcat")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	return bin
+}
 
 // cacheEnv returns environment variables that point os.UserCacheDir
 // at a temp dir on all operating systems, so test runs don't litter
@@ -41,10 +55,7 @@ func cacheEnv(t *testing.T) []string {
 // (plus TAILCAT_ADDR_FILE) to test the bottles without network
 // access, so it must not regress.
 func TestLocalDERPMode(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "tailcat")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build: %v\n%s", err, out)
-	}
+	bin := buildTailcat(t)
 
 	const derpMapURL = "http://127.0.0.1:9/unreachable"
 	addrFile := filepath.Join(t.TempDir(), "addr")
@@ -110,10 +121,7 @@ func TestLocalDERPMode(t *testing.T) {
 // server must not exit before its FIN is delivered, which once made
 // clients hang forever).
 func TestPipeMode(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "tailcat")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build: %v\n%s", err, out)
-	}
+	bin := buildTailcat(t)
 
 	dm := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1")
 	dmJSON, err := json.Marshal(dm)

--- a/cmd/tailcat/socks_test.go
+++ b/cmd/tailcat/socks_test.go
@@ -153,10 +153,7 @@ func TestClassifySOCKSAddr(t *testing.T) {
 // test existed, socks mode ignored --key and could never reach a
 // server locked down with --allow (issue #24).
 func TestSOCKSClientKey(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "tailcat")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build: %v\n%s", err, out)
-	}
+	bin := buildTailcat(t)
 
 	dm := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1")
 	dmJSON, err := json.Marshal(dm)


### PR DESCRIPTION
Run the main test job on a matrix of ubuntu-latest, macos-latest, and
windows-latest instead of Linux only, so OS-specific breakage is caught
in CI. Use fail-fast: false so one OS failing doesn't cancel the
others. The wasm job stays Linux-only since it cross-compiles and needs
Chrome.
