### PR TITLE
cmd/tailcat: make integration tests portable on Windows

### DIFF
--- a/cmd/tailcat/pipe_test.go
+++ b/cmd/tailcat/pipe_test.go
@@ -41,10 +41,7 @@ func cacheEnv(t *testing.T) []string {
 // (plus TAILCAT_ADDR_FILE) to test the bottles without network
 // access, so it must not regress.
 func TestLocalDERPMode(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "tailcat")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build: %v\n%s", err, out)
-	}
+	bin := buildTailcatTestBinary(t)
 
 	const derpMapURL = "http://127.0.0.1:9/unreachable"
 	addrFile := filepath.Join(t.TempDir(), "addr")
@@ -110,10 +107,7 @@ func TestLocalDERPMode(t *testing.T) {
 // server must not exit before its FIN is delivered, which once made
 // clients hang forever).
 func TestPipeMode(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "tailcat")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build: %v\n%s", err, out)
-	}
+	bin := buildTailcatTestBinary(t)
 
 	dm := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1")
 	dmJSON, err := json.Marshal(dm)

--- a/cmd/tailcat/socks_test.go
+++ b/cmd/tailcat/socks_test.go
@@ -153,10 +153,7 @@ func TestClassifySOCKSAddr(t *testing.T) {
 // test existed, socks mode ignored --key and could never reach a
 // server locked down with --allow (issue #24).
 func TestSOCKSClientKey(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "tailcat")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build: %v\n%s", err, out)
-	}
+	bin := buildTailcatTestBinary(t)
 
 	dm := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1")
 	dmJSON, err := json.Marshal(dm)
@@ -206,7 +203,8 @@ func TestSOCKSClientKey(t *testing.T) {
 	// The socks client pings the server before starting the proxy and
 	// exits non-zero if the ping fails, so a successful run of a
 	// trivial child command proves the allowlisted handshake worked.
-	client := exec.Command(bin, "--key="+clientKey, "--derpmap-url="+dmSrv.URL, "socks", blob, "true")
+	args := append([]string{"--key=" + clientKey, "--derpmap-url=" + dmSrv.URL, "socks", blob}, testNoopCommand()...)
+	client := exec.Command(bin, args...)
 	client.Env = append(os.Environ(), cacheEnv(t)...)
 	if out, err := client.CombinedOutput(); err != nil {
 		t.Fatalf("socks with allowlisted --key failed: %v\n%s", err, out)

--- a/cmd/tailcat/testutil_test.go
+++ b/cmd/tailcat/testutil_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func buildTailcatTestBinary(t *testing.T) string {
+	t.Helper()
+	name := "tailcat"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(t.TempDir(), name)
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func testNoopCommand() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"cmd.exe", "/d", "/c", "exit", "/b", "0"}
+	}
+	return []string{"true"}
+}


### PR DESCRIPTION
## Summary

- build command integration-test binaries with the Windows `.exe` suffix when needed
- share the build helper across `TestLocalDERPMode`, `TestPipeMode`, and `TestSOCKSClientKey`
- use a cross-platform no-op child command for the SOCKS allowlist test

On Windows, the tests previously built `tailcat.exe` but attempted to execute the extensionless `tailcat` path. After that was fixed, the SOCKS test also exposed its dependency on the POSIX-only `true` command.

The changes are test-only and do not affect Tailcat runtime behavior.

## Validation

Run on Windows/amd64 with Go 1.26.5:

- `go test ./cmd/tailcat -run "Test(LocalDERPMode|PipeMode|SOCKSClientKey)$" -count=1 -v -timeout 5m`
- `go test ./... -count=1 -timeout 10m`
- `go vet ./...`
- `git diff --check`

All passed.

Fixes #32
