### PR TITLE
tailcat, cmd/tailcat: support SSH on Windows

### DIFF
--- a/cmd/tailcat/e2e_test.go
+++ b/cmd/tailcat/e2e_test.go
@@ -116,7 +116,8 @@ func cacheEnv(t *testing.T) []string {
 	return []string{
 		"XDG_CACHE_HOME=" + dir, // Linux
 		"HOME=" + dir,           // macOS
-		"LocalAppData=" + dir,   // Windows
+		"LocalAppData=" + dir,   // Windows os.UserCacheDir
+		"AppData=" + dir,        // Windows os.UserConfigDir (SSH host key)
 	}
 }
 

--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -14,8 +14,8 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/tailscale/tailcat"
 	"tailscale.com/types/logger"
@@ -62,20 +62,27 @@ func clientSSHMode(logf logger.Logf) {
 		sshExe,
 		"-o", "UpdateHostKeys no",
 		"-o", "StrictHostKeyChecking no",
-		"-o", "UserKnownHostsFile /dev/null",
+		"-o", "UserKnownHostsFile " + os.DevNull,
 		"-o", "LogLevel ERROR",
 		"-o", "ProxyCommand=" + sshProxyCommand(exe, *flagKey, *flagDERPMapURL, connBlobStr, portOrIPPort),
 		sshDst,
 	}
 	argv = append(argv, cmdArgs...)
-	err = syscall.Exec(sshExe, argv, os.Environ())
-	log.Fatalf("failed to exec: %v", err)
+	err = execSSH(sshExe, argv)
+	log.Fatalf("failed to run ssh: %v", err)
 }
 
 // sshProxyCommand returns the command passed to OpenSSH to connect the SSH
 // client to a tailcat server. The command is run by OpenSSH, so values that
 // can contain shell-special characters must be quoted.
 func sshProxyCommand(exe, keyName, derpMapURL, connBlob, portOrIPPort string) string {
+	if runtime.GOOS == "windows" {
+		// Plain quotes without Go's %q backslash escaping: the
+		// executable is a Windows path whose backslashes must survive
+		// both cmd.exe (which Win32-OpenSSH uses to run ProxyCommand)
+		// and the child's own command line parsing.
+		exe = "\"" + exe + "\""
+	}
 	cmd := fmt.Sprintf("%s --key=%q", exe, keyName)
 	if derpMapURL != tailcat.DefaultDERPMapURL {
 		cmd += fmt.Sprintf(" --derpmap-url=%q", derpMapURL)

--- a/cmd/tailcat/ssh_e2e_test.go
+++ b/cmd/tailcat/ssh_e2e_test.go
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 // The SSH server side only exists on these platforms (see
-// tailcat.SupportsSSHServer), and the client side execs a Unix ssh.
+// tailcat.SupportsSSHServer), and the client side runs the system ssh.
 
-//go:build linux || darwin
+//go:build linux || darwin || windows
 
 package main
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -19,9 +20,10 @@ import (
 // ProxyCommand that runs the tailcat binary itself. The exec form
 // ("echo hi") never starts an interactive shell or allocates a PTY:
 // the server ignores the requested SSH user and runs the current
-// user's shell with -c. All state stays in temp dirs: the server's
-// generated host key lands under the test HOME, and the client runs
-// with StrictHostKeyChecking off and a /dev/null known hosts file.
+// user's shell (PowerShell on Windows). All state stays in temp
+// dirs: the server's generated host key lands under the test config
+// dir, and the client runs with StrictHostKeyChecking off and a null
+// known hosts file.
 func TestServeNoAuthSSH(t *testing.T) {
 	if _, err := exec.LookPath("ssh"); err != nil {
 		t.Skipf("no ssh client in $PATH: %v", err)
@@ -44,7 +46,8 @@ func TestServeNoAuthSSH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tailcat ssh: %v\n%s", err, out)
 	}
-	if got, want := string(out), "hi\n"; got != want {
+	// TrimSpace: PowerShell on Windows emits "hi\r\n".
+	if got, want := strings.TrimSpace(string(out)), "hi"; got != want {
 		t.Errorf("tailcat ssh output = %q; want %q", got, want)
 	}
 }

--- a/cmd/tailcat/ssh_exec_unix.go
+++ b/cmd/tailcat/ssh_exec_unix.go
@@ -1,0 +1,17 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build unix && !ts_omit_ssh
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// execSSH replaces the current process with the ssh client.
+// It only returns on error.
+func execSSH(sshExe string, argv []string) error {
+	return syscall.Exec(sshExe, argv, os.Environ())
+}

--- a/cmd/tailcat/ssh_exec_windows.go
+++ b/cmd/tailcat/ssh_exec_windows.go
@@ -1,0 +1,32 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows && !ts_omit_ssh
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// execSSH runs the ssh client as a child process with inherited stdio,
+// since Windows has no exec. On success it exits the whole process with
+// ssh's exit status; it only returns on failure to run ssh at all.
+func execSSH(sshExe string, argv []string) error {
+	cmd := exec.Command(sshExe, argv[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		os.Exit(exitErr.ExitCode())
+	}
+	if err != nil {
+		return err
+	}
+	os.Exit(0)
+	panic("unreachable")
+}

--- a/cmd/tailcat/ssh_test.go
+++ b/cmd/tailcat/ssh_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,15 +21,19 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 		port = "22"
 		url  = "https://derp.example.com/derpmap.json"
 	)
+	wantExe := exe
+	if runtime.GOOS == "windows" {
+		wantExe = `"` + exe + `"`
+	}
 
 	got := sshProxyCommand(exe, key, url, blob, port)
-	want := exe + ` --key="client-default" --derpmap-url="https://derp.example.com/derpmap.json" tc-short-blob 22`
+	want := wantExe + ` --key="client-default" --derpmap-url="https://derp.example.com/derpmap.json" tc-short-blob 22`
 	if got != want {
 		t.Errorf("sshProxyCommand with custom DERP map = %q; want %q", got, want)
 	}
 
 	got = sshProxyCommand(exe, key, tailcat.DefaultDERPMapURL, blob, port)
-	want = exe + ` --key="client-default" tc-short-blob 22`
+	want = wantExe + ` --key="client-default" tc-short-blob 22`
 	if got != want {
 		t.Errorf("sshProxyCommand with default DERP map = %q; want %q", got, want)
 	}

--- a/tailcat_ssh.go
+++ b/tailcat_ssh.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build (linux || darwin) && !ts_omit_ssh
+//go:build (linux || darwin || windows) && !ts_omit_ssh
 
 package tailcat
 
@@ -18,17 +18,12 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 
-	"github.com/creack/pty"
 	ssh "github.com/tailscale/gliderssh"
-	"github.com/u-root/u-root/pkg/termios"
 	gossh "golang.org/x/crypto/ssh"
-	"golang.org/x/sys/unix"
 )
 
 // SupportsSSHServer reports whether the platform supports running the built-in
@@ -38,11 +33,12 @@ func SupportsSSHServer() bool { return true }
 // HandleTailscaleSSHConn handles an incoming TCP connection as an SSH session.
 // Authentication is not required — the WireGuard tunnel provides identity.
 // The connection is served using the gliderlabs/ssh library with a single
-// ed25519 host key generated on first use in ~/.config/tailcat/ssh/.
+// ed25519 host key generated on first use under tailcat/ssh in the user's
+// config directory (os.UserConfigDir).
 //
-// Two modes are supported: if the SSH client sends a command, it is executed
-// via the user's shell with "-c"; otherwise an interactive login shell is
-// started with a PTY.
+// Two modes are supported: if the SSH client sends a command, it is run by
+// the user's shell (PowerShell on Windows); otherwise an interactive login
+// shell is started with a PTY.
 func (s *Server) HandleTailscaleSSHConn(c net.Conn) {
 	keys, err := getHostKeys()
 	if err != nil {
@@ -72,25 +68,10 @@ func sessionHandler(sess ssh.Session) {
 		return
 	}
 
-	shell := loginShell(u)
-	rawCmd := sess.RawCommand()
-
-	var args []string
-	if rawCmd == "" {
-		args = []string{shell, "-l"}
-	} else {
-		args = []string{shell, "-c", rawCmd}
-	}
-
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Dir = u.HomeDir
-
-	cmd.Env = []string{
-		"SHELL=" + shell,
-		"USER=" + u.Username,
-		"HOME=" + u.HomeDir,
-		"PATH=" + defaultPath(u),
-	}
+	// newSessionCommand is per-platform (tailcat_ssh_unix.go,
+	// tailcat_ssh_windows.go). It returns an unstarted command with
+	// Args, Dir, and the base environment set.
+	cmd := newSessionCommand(u, sess.RawCommand())
 	for _, env := range sess.Environ() {
 		if acceptEnvPair(env) {
 			cmd.Env = append(cmd.Env, env)
@@ -104,103 +85,6 @@ func sessionHandler(sess ssh.Session) {
 	} else {
 		runWithPipes(sess, cmd)
 	}
-}
-
-// runWithPTY runs cmd attached to a pseudo-terminal.
-func runWithPTY(sess ssh.Session, cmd *exec.Cmd, ptyReq ssh.Pty, winCh <-chan ssh.Window) {
-	ptmx, tty, err := pty.Open()
-	if err != nil {
-		fmt.Fprintf(sess.Stderr(), "pty open: %v\r\n", err)
-		sess.Exit(1)
-		return
-	}
-	defer ptmx.Close()
-	defer tty.Close()
-
-	// Configure terminal modes from the SSH request.
-	if rc, err := tty.SyscallConn(); err == nil {
-		rc.Control(func(fd uintptr) {
-			tios, err := termios.GTTY(int(fd))
-			if err != nil {
-				return
-			}
-			tios.Row = int(ptyReq.Window.Height)
-			tios.Col = int(ptyReq.Window.Width)
-			for c, v := range ptyReq.Modes {
-				if c == gossh.TTY_OP_ISPEED {
-					tios.Ispeed = int(v)
-					continue
-				}
-				if c == gossh.TTY_OP_OSPEED {
-					tios.Ospeed = int(v)
-					continue
-				}
-				k, ok := opcodeShortName[c]
-				if !ok {
-					continue
-				}
-				if _, ok := tios.CC[k]; ok {
-					tios.CC[k] = uint8(v)
-					continue
-				}
-				if _, ok := tios.Opts[k]; ok {
-					tios.Opts[k] = v > 0
-					continue
-				}
-			}
-			tios.STTY(int(fd))
-		})
-	}
-
-	if ptyReq.Term != "" {
-		cmd.Env = append(cmd.Env, "TERM="+ptyReq.Term)
-	}
-
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setctty: true,
-		Setsid:  true,
-	}
-	cmd.Stdin = tty
-	cmd.Stdout = tty
-	cmd.Stderr = tty
-
-	if err := cmd.Start(); err != nil {
-		fmt.Fprintf(sess.Stderr(), "start: %v\r\n", err)
-		sess.Exit(1)
-		return
-	}
-	tty.Close() // child owns the tty now
-
-	// Handle window size changes. The goroutine runs until gliderssh
-	// closes winCh, which happens only once the whole session channel
-	// shuts down, after this function has returned and closed ptmx. It
-	// therefore gets its own duplicated file descriptor rather than
-	// racing the deferred ptmx.Close (and whatever reuses that fd).
-	if winchFd, err := unix.Dup(int(ptmx.Fd())); err == nil {
-		go func() {
-			defer unix.Close(winchFd)
-			for win := range winCh {
-				unix.IoctlSetWinsize(winchFd, syscall.TIOCSWINSZ, &unix.Winsize{
-					Row:    uint16(win.Height),
-					Col:    uint16(win.Width),
-					Xpixel: uint16(win.WidthPixels),
-					Ypixel: uint16(win.HeightPixels),
-				})
-			}
-		}()
-	}
-
-	// I/O: session ↔ pty master.
-	go func() {
-		io.Copy(ptmx, sess) // stdin
-	}()
-	io.Copy(sess, ptmx) // stdout (blocks until pty closes)
-
-	if err := cmd.Wait(); err != nil {
-		sess.Exit(exitCode(err))
-		return
-	}
-	sess.Exit(0)
 }
 
 // runWithPipes runs cmd with stdin/stdout/stderr pipes (no PTY).
@@ -285,33 +169,8 @@ func acceptEnvPair(kv string) bool {
 	return k == "TERM" || k == "LANG" || strings.HasPrefix(k, "LC_")
 }
 
-// loginShell returns the user's login shell.
-func loginShell(u *user.User) string {
-	switch runtime.GOOS {
-	case "darwin":
-		out, err := exec.Command("dscl", ".", "-read", filepath.Join("/Users", u.Username), "UserShell").Output()
-		if err == nil {
-			if s, ok := strings.CutPrefix(string(out), "UserShell: "); ok {
-				return strings.TrimSpace(s)
-			}
-		}
-	}
-	if e := os.Getenv("SHELL"); e != "" {
-		return e
-	}
-	return "/bin/sh"
-}
-
-// defaultPath returns the default PATH for the given user.
-func defaultPath(u *user.User) string {
-	if u.Uid == "0" {
-		return "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	}
-	return "/usr/local/bin:/usr/bin:/bin"
-}
-
 // getHostKeys returns the SSH host key signers, generating an ed25519 key
-// in ~/.config/tailcat/ssh/ if one doesn't exist.
+// in the tailcat/ssh config directory if one doesn't exist.
 func getHostKeys() ([]gossh.Signer, error) {
 	dir, err := sshKeyDir()
 	if err != nil {
@@ -372,65 +231,4 @@ func hostKeyFileOrCreate(keyDir string) ([]byte, error) {
 		return nil, err
 	}
 	return pemData, nil
-}
-
-// opcodeShortName maps SSH terminal mode opcodes to mnemonic names
-// expected by the termios package.
-var opcodeShortName = map[uint8]string{
-	gossh.VINTR:         "intr",
-	gossh.VQUIT:         "quit",
-	gossh.VERASE:        "erase",
-	gossh.VKILL:         "kill",
-	gossh.VEOF:          "eof",
-	gossh.VEOL:          "eol",
-	gossh.VEOL2:         "eol2",
-	gossh.VSTART:        "start",
-	gossh.VSTOP:         "stop",
-	gossh.VSUSP:         "susp",
-	gossh.VDSUSP:        "dsusp",
-	gossh.VREPRINT:      "rprnt",
-	gossh.VWERASE:       "werase",
-	gossh.VLNEXT:        "lnext",
-	gossh.VFLUSH:        "flush",
-	gossh.VSWTCH:        "swtch",
-	gossh.VSTATUS:       "status",
-	gossh.VDISCARD:      "discard",
-	gossh.IGNPAR:        "ignpar",
-	gossh.PARMRK:        "parmrk",
-	gossh.INPCK:         "inpck",
-	gossh.ISTRIP:        "istrip",
-	gossh.INLCR:         "inlcr",
-	gossh.IGNCR:         "igncr",
-	gossh.ICRNL:         "icrnl",
-	gossh.IUCLC:         "iuclc",
-	gossh.IXON:          "ixon",
-	gossh.IXANY:         "ixany",
-	gossh.IXOFF:         "ixoff",
-	gossh.IMAXBEL:       "imaxbel",
-	gossh.IUTF8:         "iutf8",
-	gossh.ISIG:          "isig",
-	gossh.ICANON:        "icanon",
-	gossh.XCASE:         "xcase",
-	gossh.ECHO:          "echo",
-	gossh.ECHOE:         "echoe",
-	gossh.ECHOK:         "echok",
-	gossh.ECHONL:        "echonl",
-	gossh.NOFLSH:        "noflsh",
-	gossh.TOSTOP:        "tostop",
-	gossh.IEXTEN:        "iexten",
-	gossh.ECHOCTL:       "echoctl",
-	gossh.ECHOKE:        "echoke",
-	gossh.PENDIN:        "pendin",
-	gossh.OPOST:         "opost",
-	gossh.OLCUC:         "olcuc",
-	gossh.ONLCR:         "onlcr",
-	gossh.OCRNL:         "ocrnl",
-	gossh.ONOCR:         "onocr",
-	gossh.ONLRET:        "onlret",
-	gossh.CS7:           "cs7",
-	gossh.CS8:           "cs8",
-	gossh.PARENB:        "parenb",
-	gossh.PARODD:        "parodd",
-	gossh.TTY_OP_ISPEED: "tty_op_ispeed",
-	gossh.TTY_OP_OSPEED: "tty_op_ospeed",
 }

--- a/tailcat_ssh_stub.go
+++ b/tailcat_ssh_stub.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build ts_omit_ssh || !(linux || darwin)
+//go:build ts_omit_ssh || !(linux || darwin || windows)
 
 package tailcat
 

--- a/tailcat_ssh_test.go
+++ b/tailcat_ssh_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-//go:build (linux || darwin) && !ts_omit_ssh
+//go:build (linux || darwin || windows) && !ts_omit_ssh
 
 package tailcat_test
 
@@ -10,6 +10,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -128,10 +129,16 @@ func TestSSHSuite(t *testing.T) {
 		}
 		defer sess.Close()
 
+		// Windows PowerShell 5.1 has no && operator.
+		cmd := "echo out-marker && echo err-marker >&2"
+		if runtime.GOOS == "windows" {
+			cmd = "echo out-marker; [Console]::Error.WriteLine('err-marker')"
+		}
+
 		var stdout, stderr bytes.Buffer
 		sess.Stdout = &stdout
 		sess.Stderr = &stderr
-		if err := sess.Run("echo out-marker && echo err-marker >&2"); err != nil {
+		if err := sess.Run(cmd); err != nil {
 			t.Fatalf("Run: %v", err)
 		}
 		if !strings.Contains(stdout.String(), "out-marker") {
@@ -160,7 +167,11 @@ func TestSSHSuite(t *testing.T) {
 		if err := sess.Setenv("LC_ALL", "test-lc-val"); err != nil {
 			t.Fatalf("Setenv LC_ALL: %v", err)
 		}
-		out, err := sess.Output("echo LANG=$LANG LC_ALL=$LC_ALL")
+		cmd := "echo LANG=$LANG LC_ALL=$LC_ALL"
+		if runtime.GOOS == "windows" {
+			cmd = `echo "LANG=$env:LANG LC_ALL=$env:LC_ALL"`
+		}
+		out, err := sess.Output(cmd)
 		if err != nil {
 			t.Fatalf("Output: %v", err)
 		}
@@ -174,6 +185,9 @@ func TestSSHSuite(t *testing.T) {
 	})
 
 	t.Run("PTYAllocated", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("no tty command or /dev tty names on Windows")
+		}
 		sess, err := env.sshClient(t).NewSession()
 		if err != nil {
 			t.Fatal(err)
@@ -203,11 +217,21 @@ func TestSSHSuite(t *testing.T) {
 		if err := sess.RequestPty("xterm-256color", 24, 80, gossh.TerminalModes{}); err != nil {
 			t.Fatalf("RequestPty: %v", err)
 		}
-		out, err := sess.Output("echo $TERM")
+		cmd := "echo $TERM"
+		if runtime.GOOS == "windows" {
+			cmd = "echo $env:TERM"
+		}
+		out, err := sess.Output(cmd)
 		if err != nil {
 			t.Fatalf("echo TERM: %v", err)
 		}
-		if got := strings.TrimSpace(string(out)); got != "xterm-256color" {
+		if runtime.GOOS == "windows" {
+			// ConPTY output is decorated with VT escape sequences, so
+			// an exact match is not possible.
+			if !strings.Contains(string(out), "xterm-256color") {
+				t.Fatalf("TERM missing from output %q, want %q somewhere", out, "xterm-256color")
+			}
+		} else if got := strings.TrimSpace(string(out)); got != "xterm-256color" {
 			t.Fatalf("TERM = %q, want %q", got, "xterm-256color")
 		}
 	})
@@ -236,8 +260,14 @@ func TestSSHSuite(t *testing.T) {
 			t.Fatalf("Shell: %v", err)
 		}
 
-		io.WriteString(stdin, "echo interactive-marker-12345\n")
-		io.WriteString(stdin, "exit\n")
+		// A real terminal sends \r for Enter, and Windows console
+		// input does not treat a bare \n as a line ending.
+		nl := "\n"
+		if runtime.GOOS == "windows" {
+			nl = "\r"
+		}
+		io.WriteString(stdin, "echo interactive-marker-12345"+nl)
+		io.WriteString(stdin, "exit"+nl)
 
 		if err := sess.Wait(); err != nil {
 			// Shell exit may produce a non-zero status on some systems;
@@ -247,6 +277,54 @@ func TestSSHSuite(t *testing.T) {
 
 		if !strings.Contains(stdout.String(), "interactive-marker-12345") {
 			t.Fatalf("interactive shell output missing marker: %q", stdout.String())
+		}
+	})
+
+	t.Run("CtrlC", func(t *testing.T) {
+		sess, err := env.sshClient(t).NewSession()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sess.Close()
+
+		if err := sess.RequestPty("xterm", 24, 80, gossh.TerminalModes{}); err != nil {
+			t.Fatalf("RequestPty: %v", err)
+		}
+		stdin, err := sess.StdinPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var stdout bytes.Buffer
+		sess.Stdout = &stdout
+		if err := sess.Shell(); err != nil {
+			t.Fatalf("Shell: %v", err)
+		}
+
+		nl := "\n"
+		sleep := "sleep 60"
+		if runtime.GOOS == "windows" {
+			nl = "\r"
+			sleep = "Start-Sleep 60"
+		}
+		io.WriteString(stdin, sleep+nl)
+		time.Sleep(2 * time.Second) // let the sleep start
+		io.WriteString(stdin, "\x03")
+		time.Sleep(1 * time.Second)
+		io.WriteString(stdin, "echo after-intr-ok"+nl)
+		io.WriteString(stdin, "exit"+nl)
+
+		done := make(chan error, 1)
+		go func() { done <- sess.Wait() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Logf("Wait: %v (may be expected)", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatal("session did not exit: ^C did not interrupt the sleep")
+		}
+		if !strings.Contains(stdout.String(), "after-intr-ok") {
+			t.Fatalf("output missing post-interrupt marker: %q", stdout.String())
 		}
 	})
 }

--- a/tailcat_ssh_unix.go
+++ b/tailcat_ssh_unix.go
@@ -1,0 +1,232 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build (linux || darwin) && !ts_omit_ssh
+
+package tailcat
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/creack/pty"
+	ssh "github.com/tailscale/gliderssh"
+	"github.com/u-root/u-root/pkg/termios"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/sys/unix"
+)
+
+// newSessionCommand returns an unstarted command running the user's login
+// shell: interactively if rawCmd is empty, otherwise running rawCmd with the
+// shell's -c flag. The returned command has Args, Dir, and the base
+// environment set; the caller appends any client-provided environment.
+func newSessionCommand(u *user.User, rawCmd string) *exec.Cmd {
+	shell := loginShell(u)
+
+	var args []string
+	if rawCmd == "" {
+		args = []string{shell, "-l"}
+	} else {
+		args = []string{shell, "-c", rawCmd}
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = u.HomeDir
+	cmd.Env = []string{
+		"SHELL=" + shell,
+		"USER=" + u.Username,
+		"HOME=" + u.HomeDir,
+		"PATH=" + defaultPath(u),
+	}
+	return cmd
+}
+
+// runWithPTY runs cmd attached to a pseudo-terminal.
+func runWithPTY(sess ssh.Session, cmd *exec.Cmd, ptyReq ssh.Pty, winCh <-chan ssh.Window) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		fmt.Fprintf(sess.Stderr(), "pty open: %v\r\n", err)
+		sess.Exit(1)
+		return
+	}
+	defer ptmx.Close()
+	defer tty.Close()
+
+	// Configure terminal modes from the SSH request.
+	if rc, err := tty.SyscallConn(); err == nil {
+		rc.Control(func(fd uintptr) {
+			tios, err := termios.GTTY(int(fd))
+			if err != nil {
+				return
+			}
+			tios.Row = int(ptyReq.Window.Height)
+			tios.Col = int(ptyReq.Window.Width)
+			for c, v := range ptyReq.Modes {
+				if c == gossh.TTY_OP_ISPEED {
+					tios.Ispeed = int(v)
+					continue
+				}
+				if c == gossh.TTY_OP_OSPEED {
+					tios.Ospeed = int(v)
+					continue
+				}
+				k, ok := opcodeShortName[c]
+				if !ok {
+					continue
+				}
+				if _, ok := tios.CC[k]; ok {
+					tios.CC[k] = uint8(v)
+					continue
+				}
+				if _, ok := tios.Opts[k]; ok {
+					tios.Opts[k] = v > 0
+					continue
+				}
+			}
+			tios.STTY(int(fd))
+		})
+	}
+
+	if ptyReq.Term != "" {
+		cmd.Env = append(cmd.Env, "TERM="+ptyReq.Term)
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setctty: true,
+		Setsid:  true,
+	}
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(sess.Stderr(), "start: %v\r\n", err)
+		sess.Exit(1)
+		return
+	}
+	tty.Close() // child owns the tty now
+
+	// Handle window size changes. The goroutine runs until gliderssh
+	// closes winCh, which happens only once the whole session channel
+	// shuts down, after this function has returned and closed ptmx. It
+	// therefore gets its own duplicated file descriptor rather than
+	// racing the deferred ptmx.Close (and whatever reuses that fd).
+	if winchFd, err := unix.Dup(int(ptmx.Fd())); err == nil {
+		go func() {
+			defer unix.Close(winchFd)
+			for win := range winCh {
+				unix.IoctlSetWinsize(winchFd, syscall.TIOCSWINSZ, &unix.Winsize{
+					Row:    uint16(win.Height),
+					Col:    uint16(win.Width),
+					Xpixel: uint16(win.WidthPixels),
+					Ypixel: uint16(win.HeightPixels),
+				})
+			}
+		}()
+	}
+
+	// I/O: session ↔ pty master.
+	go func() {
+		io.Copy(ptmx, sess) // stdin
+	}()
+	io.Copy(sess, ptmx) // stdout (blocks until pty closes)
+
+	if err := cmd.Wait(); err != nil {
+		sess.Exit(exitCode(err))
+		return
+	}
+	sess.Exit(0)
+}
+
+// loginShell returns the user's login shell.
+func loginShell(u *user.User) string {
+	switch runtime.GOOS {
+	case "darwin":
+		out, err := exec.Command("dscl", ".", "-read", filepath.Join("/Users", u.Username), "UserShell").Output()
+		if err == nil {
+			if s, ok := strings.CutPrefix(string(out), "UserShell: "); ok {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	if e := os.Getenv("SHELL"); e != "" {
+		return e
+	}
+	return "/bin/sh"
+}
+
+// defaultPath returns the default PATH for the given user.
+func defaultPath(u *user.User) string {
+	if u.Uid == "0" {
+		return "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	}
+	return "/usr/local/bin:/usr/bin:/bin"
+}
+
+// opcodeShortName maps SSH terminal mode opcodes to mnemonic names
+// expected by the termios package.
+var opcodeShortName = map[uint8]string{
+	gossh.VINTR:         "intr",
+	gossh.VQUIT:         "quit",
+	gossh.VERASE:        "erase",
+	gossh.VKILL:         "kill",
+	gossh.VEOF:          "eof",
+	gossh.VEOL:          "eol",
+	gossh.VEOL2:         "eol2",
+	gossh.VSTART:        "start",
+	gossh.VSTOP:         "stop",
+	gossh.VSUSP:         "susp",
+	gossh.VDSUSP:        "dsusp",
+	gossh.VREPRINT:      "rprnt",
+	gossh.VWERASE:       "werase",
+	gossh.VLNEXT:        "lnext",
+	gossh.VFLUSH:        "flush",
+	gossh.VSWTCH:        "swtch",
+	gossh.VSTATUS:       "status",
+	gossh.VDISCARD:      "discard",
+	gossh.IGNPAR:        "ignpar",
+	gossh.PARMRK:        "parmrk",
+	gossh.INPCK:         "inpck",
+	gossh.ISTRIP:        "istrip",
+	gossh.INLCR:         "inlcr",
+	gossh.IGNCR:         "igncr",
+	gossh.ICRNL:         "icrnl",
+	gossh.IUCLC:         "iuclc",
+	gossh.IXON:          "ixon",
+	gossh.IXANY:         "ixany",
+	gossh.IXOFF:         "ixoff",
+	gossh.IMAXBEL:       "imaxbel",
+	gossh.IUTF8:         "iutf8",
+	gossh.ISIG:          "isig",
+	gossh.ICANON:        "icanon",
+	gossh.XCASE:         "xcase",
+	gossh.ECHO:          "echo",
+	gossh.ECHOE:         "echoe",
+	gossh.ECHOK:         "echok",
+	gossh.ECHONL:        "echonl",
+	gossh.NOFLSH:        "noflsh",
+	gossh.TOSTOP:        "tostop",
+	gossh.IEXTEN:        "iexten",
+	gossh.ECHOCTL:       "echoctl",
+	gossh.ECHOKE:        "echoke",
+	gossh.PENDIN:        "pendin",
+	gossh.OPOST:         "opost",
+	gossh.OLCUC:         "olcuc",
+	gossh.ONLCR:         "onlcr",
+	gossh.OCRNL:         "ocrnl",
+	gossh.ONOCR:         "onocr",
+	gossh.ONLRET:        "onlret",
+	gossh.CS7:           "cs7",
+	gossh.CS8:           "cs8",
+	gossh.PARENB:        "parenb",
+	gossh.PARODD:        "parodd",
+	gossh.TTY_OP_ISPEED: "tty_op_ispeed",
+	gossh.TTY_OP_OSPEED: "tty_op_ospeed",
+}

--- a/tailcat_ssh_windows.go
+++ b/tailcat_ssh_windows.go
@@ -1,0 +1,350 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+//go:build windows && !ts_omit_ssh
+
+package tailcat
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unsafe"
+
+	ssh "github.com/tailscale/gliderssh"
+	"golang.org/x/sys/windows"
+)
+
+// newSessionCommand returns an unstarted command running PowerShell:
+// interactively if rawCmd is empty, otherwise running rawCmd with
+// PowerShell's -Command flag. The returned command has Args, Dir, and the
+// base environment set; the caller appends any client-provided environment.
+func newSessionCommand(u *user.User, rawCmd string) *exec.Cmd {
+	clearInheritedCtrlCIgnore()
+	shell := powerShellPath()
+
+	var args []string
+	if rawCmd == "" {
+		args = []string{shell, "-NoLogo"}
+	} else {
+		args = []string{shell, "-Command", rawCmd}
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = u.HomeDir
+	// Unlike the minimal environment built on Unix, Windows processes
+	// need most of the parent environment (SystemRoot, TEMP, and
+	// friends) to function, so the session inherits it wholesale.
+	cmd.Env = os.Environ()
+	return cmd
+}
+
+// powerShellPath returns the path of the Windows PowerShell executable.
+func powerShellPath() string {
+	if p, err := exec.LookPath("powershell.exe"); err == nil {
+		return p
+	}
+	return filepath.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+}
+
+var (
+	kernel32                      = windows.NewLazySystemDLL("kernel32.dll")
+	procCreatePseudoConsole       = kernel32.NewProc("CreatePseudoConsole")
+	procUpdateProcThreadAttribute = kernel32.NewProc("UpdateProcThreadAttribute")
+	procSetConsoleCtrlHandler     = kernel32.NewProc("SetConsoleCtrlHandler")
+)
+
+// clearInheritedCtrlCIgnore clears this process's "ignore Ctrl-C"
+// console flag, which session children inherit at creation. The server
+// process can itself inherit the flag from whatever spawned it
+// (Win32-OpenSSH's sshd sets it on the shells it starts, for example),
+// and a child that inherits it never receives console Ctrl-C events,
+// so ^C in an interactive SSH session would be silently dropped.
+//
+// SetConsoleCtrlHandler(NULL, FALSE) clears the flag without touching
+// installed handlers (x/sys/windows has no wrapper for the NULL form).
+var clearInheritedCtrlCIgnore = sync.OnceFunc(func() {
+	procSetConsoleCtrlHandler.Call(0, 0)
+})
+
+// conPTYAvailable reports whether this Windows version has the
+// pseudoconsole API (Windows 10 1809 or later). Calling the
+// x/sys/windows pseudoconsole functions without this check would
+// panic on older systems.
+var conPTYAvailable = sync.OnceValue(func() bool {
+	return procCreatePseudoConsole.Find() == nil
+})
+
+// runWithPTY runs cmd attached to a Windows pseudoconsole (ConPTY). The
+// *exec.Cmd is used only as a carrier of Args, Env, and Dir; the process is
+// created by startConPTY, never started via the exec package.
+func runWithPTY(sess ssh.Session, cmd *exec.Cmd, ptyReq ssh.Pty, winCh <-chan ssh.Window) {
+	if !conPTYAvailable() {
+		fmt.Fprintf(sess.Stderr(), "tailcat: no ConPTY on this Windows version; running without a PTY\r\n")
+		runWithPipes(sess, cmd)
+		return
+	}
+
+	if ptyReq.Term != "" {
+		cmd.Env = append(cmd.Env, "TERM="+ptyReq.Term)
+	}
+
+	cp, err := startConPTY(cmd, ptyReq.Window.Width, ptyReq.Window.Height)
+	if err != nil {
+		fmt.Fprintf(sess.Stderr(), "conpty: %v\r\n", err)
+		sess.Exit(1)
+		return
+	}
+	defer cp.Close()
+
+	go io.Copy(cp.inWrite, sess) // stdin
+
+	// Handle window size changes. The goroutine runs until gliderssh
+	// closes winCh, which happens only once the whole session channel
+	// shuts down, possibly after this function has returned; Resize is
+	// a no-op once the pseudoconsole has been closed.
+	go func() {
+		for win := range winCh {
+			cp.Resize(win.Width, win.Height)
+		}
+	}()
+
+	// Drain process output. This reader must be running before the
+	// CloseConsole call below: closing the pseudoconsole can block
+	// until its pending output has been consumed.
+	outDone := make(chan struct{})
+	go func() {
+		defer close(outDone)
+		io.Copy(sess, cp.outRead)
+	}()
+
+	code, err := cp.WaitExitCode()
+
+	// Closing the pseudoconsole makes conhost release its handle on
+	// the output pipe, which is what lets the reader above see EOF.
+	cp.CloseConsole()
+	<-outDone
+
+	if err != nil {
+		fmt.Fprintf(sess.Stderr(), "wait: %v\r\n", err)
+		sess.Exit(1)
+		return
+	}
+	sess.Exit(code)
+}
+
+// conPTY is a Windows pseudoconsole with a single process attached to it.
+type conPTY struct {
+	inWrite *os.File // the attached process reads its input from here
+	outRead *os.File // the attached process's output is read from here
+	proc    windows.Handle
+
+	mu     sync.Mutex // guards hpc and closed: Resize races CloseConsole
+	hpc    windows.Handle
+	closed bool
+}
+
+// startConPTY creates a pseudoconsole with the given dimensions and starts a
+// process attached to it, taking the program arguments, environment, and
+// working directory from cmd. The command is never started via the exec
+// package: pseudoconsole attachment requires creating the process directly.
+func startConPTY(cmd *exec.Cmd, width, height int) (*conPTY, error) {
+	// CreatePseudoConsole rejects empty dimensions, which SSH clients
+	// without a real terminal (ssh -tt from a pipe, say) can send.
+	if width <= 0 {
+		width = 80
+	}
+	if height <= 0 {
+		height = 24
+	}
+	inRead, inWrite, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	outRead, outWrite, err := os.Pipe()
+	if err != nil {
+		inRead.Close()
+		inWrite.Close()
+		return nil, err
+	}
+
+	var hpc windows.Handle
+	err = windows.CreatePseudoConsole(
+		windows.Coord{X: int16(width), Y: int16(height)},
+		windows.Handle(inRead.Fd()),
+		windows.Handle(outWrite.Fd()),
+		0, &hpc)
+	// The pseudoconsole duplicates the handles it needs, so our copies
+	// of its two pipe ends are closed here regardless of error.
+	inRead.Close()
+	outWrite.Close()
+	if err != nil {
+		inWrite.Close()
+		outRead.Close()
+		return nil, fmt.Errorf("CreatePseudoConsole: %w", err)
+	}
+	cleanup := func() {
+		windows.ClosePseudoConsole(hpc)
+		inWrite.Close()
+		outRead.Close()
+	}
+
+	attrs, err := windows.NewProcThreadAttributeList(1)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	defer attrs.Delete()
+	if err := updatePseudoConsoleAttr(attrs.List(), hpc); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	cmdLine, err := windows.UTF16FromString(windows.ComposeCommandLine(cmd.Args))
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	var dir *uint16
+	if cmd.Dir != "" {
+		dir, err = windows.UTF16PtrFromString(cmd.Dir)
+		if err != nil {
+			cleanup()
+			return nil, err
+		}
+	}
+	env, err := envBlock(cmd.Env)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	si := &windows.StartupInfoEx{
+		// STARTF_USESTDHANDLES with the std handles left NULL keeps
+		// the child from inheriting this process's console handles;
+		// without it the child's output bypasses the pseudoconsole
+		// and lands on the parent's console.
+		StartupInfo: windows.StartupInfo{
+			Cb:    uint32(unsafe.Sizeof(windows.StartupInfoEx{})),
+			Flags: windows.STARTF_USESTDHANDLES,
+		},
+		ProcThreadAttributeList: attrs.List(),
+	}
+	var pi windows.ProcessInformation
+	err = windows.CreateProcess(nil, &cmdLine[0], nil, nil, false,
+		windows.CREATE_UNICODE_ENVIRONMENT|windows.EXTENDED_STARTUPINFO_PRESENT,
+		env, dir, &si.StartupInfo, &pi)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("CreateProcess: %w", err)
+	}
+	windows.CloseHandle(pi.Thread)
+
+	return &conPTY{
+		inWrite: inWrite,
+		outRead: outRead,
+		proc:    pi.Process,
+		hpc:     hpc,
+	}, nil
+}
+
+// updatePseudoConsoleAttr sets the pseudoconsole attribute on the list.
+// It calls UpdateProcThreadAttribute directly rather than through the
+// x/sys/windows wrapper: the attribute's value is the pseudoconsole handle
+// itself rather than a pointer, and converting a handle to the wrapper's
+// unsafe.Pointer argument trips go vet's unsafeptr check.
+func updatePseudoConsoleAttr(list *windows.ProcThreadAttributeList, hpc windows.Handle) error {
+	r1, _, e1 := procUpdateProcThreadAttribute.Call(
+		uintptr(unsafe.Pointer(list)),
+		0,
+		windows.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		uintptr(hpc),
+		unsafe.Sizeof(hpc),
+		0, 0)
+	if r1 == 0 {
+		return e1
+	}
+	return nil
+}
+
+// Resize changes the pseudoconsole dimensions. It is a no-op after
+// CloseConsole.
+func (c *conPTY) Resize(width, height int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	return windows.ResizePseudoConsole(c.hpc, windows.Coord{X: int16(width), Y: int16(height)})
+}
+
+// WaitExitCode waits for the attached process to exit and returns its exit
+// code.
+func (c *conPTY) WaitExitCode() (int, error) {
+	if _, err := windows.WaitForSingleObject(c.proc, windows.INFINITE); err != nil {
+		return 0, err
+	}
+	var code uint32
+	if err := windows.GetExitCodeProcess(c.proc, &code); err != nil {
+		return 0, err
+	}
+	return int(code), nil
+}
+
+// CloseConsole closes the pseudoconsole itself, without touching the pipes
+// or the process handle.
+func (c *conPTY) CloseConsole() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.closed {
+		windows.ClosePseudoConsole(c.hpc)
+		c.closed = true
+	}
+}
+
+// Close releases everything: the pseudoconsole if still open, both pipe
+// ends, and the process handle.
+func (c *conPTY) Close() {
+	c.CloseConsole()
+	c.inWrite.Close()
+	c.outRead.Close()
+	windows.CloseHandle(c.proc)
+}
+
+// envBlock converts a []string of key=value pairs to the UTF-16,
+// NUL-separated, double-NUL-terminated block CreateProcess expects.
+// Windows environment keys are case-insensitive and duplicates are not
+// allowed in the block, so later entries (such as client-provided TERM or
+// LANG values appended after os.Environ) replace earlier ones.
+func envBlock(env []string) (*uint16, error) {
+	seen := make(map[string]int) // uppercased key -> index in list
+	var list []string
+	for _, kv := range env {
+		k, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		uk := strings.ToUpper(k)
+		if i, dup := seen[uk]; dup {
+			list[i] = kv
+		} else {
+			seen[uk] = len(list)
+			list = append(list, kv)
+		}
+	}
+	var block []uint16
+	for _, kv := range list {
+		u, err := windows.UTF16FromString(kv) // NUL-terminated
+		if err != nil {
+			return nil, err
+		}
+		block = append(block, u...)
+	}
+	block = append(block, 0)
+	return &block[0], nil
+}


### PR DESCRIPTION
Retire the stub on Windows and run the built-in auth-free SSH server
there too. The portable pieces of tailcat_ssh.go (host keys, session
dispatch, the pipes path) stay shared; the Unix PTY code moves to
tailcat_ssh_unix.go unchanged, and a new tailcat_ssh_windows.go
implements the PTY path with a hand-rolled ConPTY layer on
golang.org/x/sys/windows, so no new dependency. Sessions run Windows
PowerShell, interactively or via -Command, and inherit the parent
environment since Windows processes need SystemRoot and friends.

Two non-obvious ConPTY details: CreateProcess gets STARTF_USESTDHANDLES
with NULL std handles, since without it the child inherits the parent's
console handles and its output bypasses the pseudoconsole entirely; and
the server clears the process's inherited "ignore Ctrl-C" console flag
before spawning session children, since children inherit it and ^C in
an interactive session is silently dropped otherwise (Win32-OpenSSH's
sshd sets that flag on the shells it starts, so a tailcat server
launched over ssh inherits it).

Client mode previously compiled on Windows but died at runtime,
because syscall.Exec there is a stub returning an error. Run ssh as a
child process instead, propagating its exit code, and quote the
ProxyCommand executable path with plain quotes so backslashes survive
cmd.exe, which is how Win32-OpenSSH runs ProxyCommand.

Tested on Windows Server 2022: the in-process SSH suite (exec, exit
codes, stderr separation, env forwarding, ConPTY sessions, ^C
interrupt) and the end-to-end --serve=no-auth-ssh plus "tailcat ssh"
loopback, which now also run on Windows CI.

Updates tailscale/tailscale#4697
