### PR TITLE
cmd/tailcat: port the CLI to ff/v4 declarative commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ starting a fresh single-use server or re-listening on an address you may
 have shared in the past.
 
 ```sh
-$ tailcat genkey --region=nyc
+$ tailcat genkey --key=default --region=nyc
 # prints the token; key saved to ~/.config/tailcat/keys/default.private.json
 
 # later; the key named "default" is used automatically once it exists:
@@ -302,7 +302,7 @@ On the client machine, generate a client identity keypair. It prints
 the public key, which is all the server needs to know:
 
 ```sh
-client$ tailcat genkey --client
+client$ tailcat genkey --client --key=client-default
 # wrote file to ~/.config/tailcat/keys/client-default.private.json
 nodekey:cfb6bfa77a0654d7450947fd6acef17d2cd848da1d30b2540b13dac272ddfd16
 ```
@@ -311,7 +311,7 @@ On the server, generate a server keypair pinned to its nearest DERP
 region (see why below), then serve SSH to only that client:
 
 ```sh
-server$ tailcat genkey --fixed-region
+server$ tailcat genkey --key=default --fixed-region
 # wrote file to ~/.config/tailcat/keys/default.private.json
 tcXXXXXXXXX
 
@@ -339,7 +339,7 @@ server, or even learn that one is running.
 Why `--fixed-region`: it discovers the nearest DERP region once, at
 genkey time, and bakes its ID into both the printed token and the
 saved key file, so server restarts bind to the same region (keeping
-the published token valid) without re-probing. Plain `tailcat genkey`
+the published token valid) without re-probing. Otherwise genkey
 defaults to `--region=auto`, which instead bakes in "pick at
 startup": fine for one-off use, but a token published in DNS should
 name a fixed region so clients and future server restarts all
@@ -358,7 +358,7 @@ itself via Let's Encrypt), then generate a server key that uses it by
 passing its hostname (or several, comma-separated) as the region:
 
 ```sh
-server$ tailcat genkey --region=derp.example.com
+server$ tailcat genkey --key=default --region=derp.example.com
 tcomFwWCCAIsKOqPUux6ClG2RM4A_vOq4VBzGgHGGjq9OsJuFKSWFygaFhToGhYWhwZGVycC5leGFtcGxlLmNvbQ
 
 server$ tailcat --serve=22

--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v4"
+	"github.com/peterbourgon/ff/v4/ffhelp"
+)
+
+// TestHelpListsCommandTree verifies that the generated root help
+// mentions every subcommand and the global flags, the declarative
+// help dump that motivated the ff port.
+func TestHelpListsCommandTree(t *testing.T) {
+	help := ffhelp.Command(newRootCommand()).String()
+	for _, want := range []string{
+		"ping", "socks", "ssh", "parse", "resolve", "genkey", "printpub",
+		"version", "readme",
+		"--serve", "--key", "--allow", "--derpmap-url", "--full-address",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("root help is missing %q", want)
+		}
+	}
+	if strings.Contains(help, "\n  -serve") {
+		t.Errorf("root help renders single-dash flags")
+	}
+}
+
+// parseCLI parses args against a fresh command tree and returns the
+// root command. It doesn't run anything.
+func parseCLI(t *testing.T, args ...string) (root *ff.Command, err error) {
+	t.Helper()
+	root = newRootCommand()
+	return root, root.Parse(args)
+}
+
+// TestSSHTrailingArgs verifies that flag parsing stops at the ssh
+// destination, so a remote command's own flags (here "-la") are
+// passed through rather than parsed.
+func TestSSHTrailingArgs(t *testing.T) {
+	root, err := parseCLI(t, "ssh", "-p", "2222", "user@tcblob", "ls", "-la")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel := root.GetSelected()
+	if sel.Name != "ssh" {
+		t.Fatalf("selected command = %q; want ssh", sel.Name)
+	}
+	f, ok := sel.Flags.GetFlag("p")
+	if !ok {
+		t.Fatal("no -p flag")
+	}
+	if got := f.GetValue(); got != "2222" {
+		t.Errorf("-p = %q; want 2222", got)
+	}
+	got := sel.Flags.(*ff.FlagSet).GetArgs()
+	want := []string{"user@tcblob", "ls", "-la"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("leftover args = %q; want %q", got, want)
+	}
+}
+
+// TestSocksTrailingArgs verifies that a child command's flags after
+// the address blob are left unparsed.
+func TestSocksTrailingArgs(t *testing.T) {
+	root, err := parseCLI(t, "socks", "--listen=1080", "tcblob", "curl", "--fail", "http://x/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel := root.GetSelected()
+	if sel.Name != "socks" {
+		t.Fatalf("selected command = %q; want socks", sel.Name)
+	}
+	got := sel.Flags.(*ff.FlagSet).GetArgs()
+	want := []string{"tcblob", "curl", "--fail", "http://x/"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("leftover args = %q; want %q", got, want)
+	}
+}
+
+// TestGlobalFlagPlacement verifies that global flags work both before
+// the subcommand (the only placement the old CLI accepted) and after
+// it (via flag set parenting).
+func TestGlobalFlagPlacement(t *testing.T) {
+	for _, args := range [][]string{
+		{"--key=new", "--derpmap-url=http://d/", "ping", "--timeout=5s", "tcblob"},
+		{"ping", "--key=new", "--derpmap-url=http://d/", "--timeout=5s", "tcblob"},
+	} {
+		if _, err := parseCLI(t, args...); err != nil {
+			t.Fatalf("parse %q: %v", args, err)
+		}
+		if *flagKey != "new" {
+			t.Errorf("parse %q: --key = %q; want new", args, *flagKey)
+		}
+		if *flagDERPMapURL != "http://d/" {
+			t.Errorf("parse %q: --derpmap-url = %q; want http://d/", args, *flagDERPMapURL)
+		}
+	}
+}
+
+// TestHelpRequests verifies that -h, --help, and the help argument
+// all report ErrHelp instead of being treated as an address blob.
+func TestHelpRequests(t *testing.T) {
+	for _, args := range [][]string{
+		{"-h"},
+		{"--help"},
+		{"genkey", "--help"},
+		{"ssh", "-h"},
+	} {
+		if _, err := parseCLI(t, args...); !errors.Is(err, ff.ErrHelp) {
+			t.Errorf("parse %q: err = %v; want ErrHelp", args, err)
+		}
+	}
+
+	root, err := parseCLI(t, "help")
+	if err != nil {
+		t.Fatalf("parse help: %v", err)
+	}
+	if err := root.Run(t.Context()); !errors.Is(err, ff.ErrHelp) {
+		t.Errorf("run help: err = %v; want ErrHelp", err)
+	}
+}
+
+// TestGenkeyRequiresKeyName verifies that genkey no longer invents a
+// key name: writing a key to disk is a big enough action that the
+// user has to pick the name, with the magic names suggested.
+func TestGenkeyRequiresKeyName(t *testing.T) {
+	for _, tt := range []struct {
+		args []string
+		want string // expected substring of the error
+	}{
+		{[]string{"genkey"}, `"default"`},
+		{[]string{"genkey", "--client"}, `"client-default"`},
+	} {
+		root, err := parseCLI(t, tt.args...)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tt.args, err)
+		}
+		err = root.Run(t.Context())
+		if err == nil || !strings.Contains(err.Error(), "--key=<name>") || !strings.Contains(err.Error(), tt.want) {
+			t.Errorf("run %q: err = %v; want one requiring --key=<name> and mentioning %s", tt.args, err, tt.want)
+		}
+		var ue usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("run %q: err is not a usageError", tt.args)
+		}
+	}
+}
+
+// TestVersionSubcommand verifies that "tailcat version" dispatches to
+// the version subcommand rather than being treated as an address blob.
+func TestVersionSubcommand(t *testing.T) {
+	root, err := parseCLI(t, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sel := root.GetSelected(); sel.Name != "version" {
+		t.Errorf("selected command = %q; want version", sel.Name)
+	}
+}
+
+// TestUnknownArgSelectsRoot verifies that a non-subcommand first
+// argument still selects the root command, whose exec treats it as an
+// address blob in client pipe mode.
+func TestUnknownArgSelectsRoot(t *testing.T) {
+	root, err := parseCLI(t, "tcSOMEBLOB", "80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sel := root.GetSelected(); sel != root {
+		t.Errorf("selected command = %q; want root", sel.Name)
+	}
+}

--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -6,9 +6,9 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"log"
 	"net/netip"
@@ -17,26 +17,34 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/peterbourgon/ff/v4"
 	"github.com/tailscale/tailcat"
-	"tailscale.com/types/logger"
 )
 
 const tailCatSSHEnabled = true
 
-func clientSSHMode(logf logger.Logf) {
-	args := flag.Args()
-	args = args[1:] // trim off "ssh"
-	if len(args) == 0 {
-		usage("tailcat ssh [-p <port|ip:port>] [user@]<addrblob> [command ...]")
+// sshCommand returns the "tailcat ssh" subcommand, with parent as the
+// parent flag set for the global flags.
+func sshCommand(parent *ff.FlagSet) *ff.Command {
+	fs := ff.NewFlagSet("ssh").SetParent(parent)
+	port := fs.StringShort('p', "22", "port number, or ip:port to reach via the server's exit node; a bare IP means port 22 on it")
+	return &ff.Command{
+		Name:      "ssh",
+		Usage:     "tailcat ssh [-p <port|ip:port>] [user@]<addrblob> [<command> [args...]]",
+		ShortHelp: "connect the system ssh client through a tailcat server",
+		Flags:     fs,
+		Exec: func(ctx context.Context, args []string) error {
+			return clientSSHMode(*port, args)
+		},
 	}
+}
 
-	portOrIPPort := "22"
-	if len(args) >= 2 && args[0] == "-p" {
-		portOrIPPort = args[1]
-		args = args[2:]
-		if ip, err := netip.ParseAddr(portOrIPPort); err == nil {
-			portOrIPPort = netip.AddrPortFrom(ip, 22).String()
-		}
+func clientSSHMode(portOrIPPort string, args []string) error {
+	if len(args) == 0 {
+		return usagef("ssh requires a [user@]<addrblob> destination argument")
+	}
+	if ip, err := netip.ParseAddr(portOrIPPort); err == nil {
+		portOrIPPort = netip.AddrPortFrom(ip, 22).String()
 	}
 	dst := args[0] // either a derpaddr alone or "user@<derpaddr>"
 	cmdArgs := args[1:]
@@ -70,6 +78,7 @@ func clientSSHMode(logf logger.Logf) {
 	argv = append(argv, cmdArgs...)
 	err = execSSH(sshExe, argv)
 	log.Fatalf("failed to run ssh: %v", err)
+	return nil
 }
 
 // sshProxyCommand returns the command passed to OpenSSH to connect the SSH

--- a/cmd/tailcat/ssh_stub.go
+++ b/cmd/tailcat/ssh_stub.go
@@ -6,14 +6,24 @@
 package main
 
 import (
-	"os"
+	"context"
+	"errors"
 
-	"tailscale.com/types/logger"
+	"github.com/peterbourgon/ff/v4"
 )
 
 const tailCatSSHEnabled = false
 
-func clientSSHMode(logf logger.Logf) {
-	logf("ssh support not compiled in")
-	os.Exit(1)
+// sshCommand returns a stub "tailcat ssh" subcommand that only
+// reports that SSH support was omitted from this build.
+func sshCommand(parent *ff.FlagSet) *ff.Command {
+	return &ff.Command{
+		Name:      "ssh",
+		Usage:     "tailcat ssh",
+		ShortHelp: "(SSH support not included in this build)",
+		Flags:     ff.NewFlagSet("ssh").SetParent(parent),
+		Exec: func(ctx context.Context, args []string) error {
+			return errors.New("ssh support not compiled in")
+		},
+	}
 }

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -31,6 +30,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/peterbourgon/ff/v4"
+	"github.com/peterbourgon/ff/v4/ffhelp"
 	"github.com/tailscale/tailcat"
 	"go4.org/mem"
 	xmaps "golang.org/x/exp/maps"
@@ -46,26 +47,179 @@ import (
 	"tailscale.com/wgengine/filter"
 )
 
+// The global flags, shared by all subcommands. They're set by
+// newRootCommand, which must run before any of them are dereferenced.
 var (
-	flagServe       = flag.String("serve", "", "comma-separated list of port numbers, port ranges, or service names to serve. Service names are: 'all' (serve all ports), 'exit-node' (run an exit node for all addresses), 'no-auth-ssh' (auth-free SSH server). If empty, it listens only on port 0 and writes to stdout.")
-	flagKey         = flag.String("key", "", "'new' for an ephemeral key. If empty, the default saved key is used if it exists ('default' in server mode, 'client-default' in client modes; see genkey), else an ephemeral key. Otherwise the path to a *.private.json or a name like 'foo' to read it from $CONFIG/tailcat/keys/foo.private.json")
-	flagAllow       = flag.String("allow", "", "comma-separated list of public keys to allow access to the server, or 'none' to allow no clients. If empty, all clients are allowed.")
-	flagVerbose     = flag.Bool("verbose", false, "be verbose")
-	flagReadme      = flag.Bool("readme", false, "print the tailcat README (documentation with usage examples) and exit")
-	flagVersion     = flag.Bool("version", false, "print the tailcat version and exit")
-	flagFullAddress = flag.Bool("full-address", false, "in server mode, print a longer connection address token with embedded DERP server info instead of a reference to a DERP map region ID. This lets clients connect more quickly, without a DERP map fetch.")
-	flagJSON        = flag.Bool("json", false, "in server mode, write {\"listenAddr\": ...} JSON to stdout")
-
-	flagDERPMapURL = flag.String("derpmap-url", tailcat.DefaultDERPMapURL, "URL of the JSON DERP map used to resolve or auto-select a DERP region")
+	flagServe       *string
+	flagKey         *string
+	flagAllow       *string
+	flagVerbose     *bool
+	flagVersion     *bool
+	flagFullAddress *bool
+	flagJSON        *bool
+	flagDERPMapURL  *string
 )
 
-func usage(err string) {
-	if err != "" {
-		fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
-	}
-	fmt.Fprintf(os.Stderr, `Usage:
+// The genkey subcommand's flags, likewise set by newRootCommand.
+var (
+	genkeyFS           *ff.FlagSet
+	genkeyKey          *string
+	genkeyClient       *bool
+	genkeyForce        *bool
+	genkeyDelete       *bool
+	genkeyList         *bool
+	genkeyRegion       *string
+	genkeyFixedRegion  *bool
+	genkeyEmbedDERPMap *bool
+)
 
-Server mode, accept one connection (any port), write to stdout:
+// getLogf returns the logger implied by the --verbose flag.
+func getLogf() logger.Logf {
+	if *flagVerbose {
+		return log.Printf
+	}
+	return logger.Discard
+}
+
+// newRootCommand builds the tailcat command tree. It must only be
+// called once per process outside of tests, as it resets the
+// package-level flag value pointers.
+func newRootCommand() *ff.Command {
+	rootFS := ff.NewFlagSet("tailcat")
+	flagServe = rootFS.StringLong("serve", "", "comma-separated list of port numbers, port ranges, or service names to serve. Service names are: 'all' (serve all ports), 'exit-node' (run an exit node for all addresses), 'no-auth-ssh' (auth-free SSH server). If empty, it accepts a single connection on any port, writes it to stdout, and exits.")
+	flagKey = rootFS.StringLong("key", "", "'new' for an ephemeral key. If empty, the default saved key is used if it exists ('default' in server mode, 'client-default' in client modes; see genkey), else an ephemeral key. Otherwise the path to a *.private.json or a name like 'foo' to read it from $CONFIG/tailcat/keys/foo.private.json")
+	flagAllow = rootFS.StringLong("allow", "", "comma-separated list of public keys to allow access to the server, or 'none' to allow no clients. If empty, all clients are allowed.")
+	flagVerbose = rootFS.BoolLong("verbose", "be verbose")
+	flagVersion = rootFS.BoolLong("version", "print the tailcat version and exit")
+	flagFullAddress = rootFS.BoolLong("full-address", "in server mode, print a longer connection address token with embedded DERP server info instead of a reference to a DERP map region ID. This lets clients connect more quickly, without a DERP map fetch.")
+	flagJSON = rootFS.BoolLong("json", "in server mode, write {\"listenAddr\": ...} JSON to stdout")
+	flagDERPMapURL = rootFS.StringLong("derpmap-url", tailcat.DefaultDERPMapURL, "URL of the JSON DERP map used to resolve or auto-select a DERP region")
+
+	pingFS := ff.NewFlagSet("ping").SetParent(rootFS)
+	pingUntilDirect := pingFS.BoolLong("until-direct", "keep pinging until a pong arrives over a direct (non-DERP) path; exit non-zero if that doesn't happen before --timeout")
+	pingTimeout := pingFS.DurationLong("timeout", 10*time.Second, "give up after this long")
+
+	socksFS := ff.NewFlagSet("socks").SetParent(rootFS)
+	socksListen := socksFS.StringLong("listen", "127.0.0.1:0", "SOCKS5 proxy listen [address]:port; a bare port means localhost, a bare address means an OS-assigned port")
+
+	keysDir := "$CONFIG/tailcat/keys"
+	if confDir, err := os.UserConfigDir(); err == nil {
+		keysDir = filepath.Join(confDir, "tailcat", "keys")
+	}
+	genkeyFS = ff.NewFlagSet("genkey").SetParent(rootFS)
+	genkeyKey = genkeyFS.StringLong("key", "", "key path (if it contains a slash) or name (written to "+keysDir+"/<name>.private.json). Required. The name 'default' is magic: server mode loads it automatically once it exists. Likewise 'client-default' for client modes.")
+	genkeyClient = genkeyFS.BoolLong("client", "generate a client identity key (no DERP region) and print its public key, for use with servers' --allow lists. The 'client-default' key is used automatically by client modes.")
+	genkeyForce = genkeyFS.BoolLong("force", "force overwrite of existing key")
+	genkeyDelete = genkeyFS.BoolLong("delete", "delete the key named by --key instead of generating one; --key is required and must be a name, not a path")
+	genkeyList = genkeyFS.BoolLong("list", "list saved key names and exit")
+	genkeyRegion = genkeyFS.StringLong("region", "auto", "region ID, code, or substring to use. Or a hostname(s) comma-separated to use a custom DERP server(s). If 'auto', one is picked based on latency at each server startup. If 'list', list all regions.")
+	genkeyFixedRegion = genkeyFS.BoolLong("fixed-region", "discover the nearest DERP region once, now, and bake it into the key and token, so future server startups (and clients) use it without re-probing")
+	genkeyEmbedDERPMap = genkeyFS.BoolLong("embed-derp-map", "embed the DERP map nodes in the connection string")
+
+	return &ff.Command{
+		Name:      "tailcat",
+		Usage:     "tailcat [flags] [<subcommand> [flags]] [args...]",
+		ShortHelp: "securely pipe or serve network connections over Tailscale's data plane (WireGuard®, NAT traversal), without Tailscale's control plane (central server, accounts)",
+		LongHelp:  rootLongHelp,
+		Flags:     rootFS,
+		Subcommands: []*ff.Command{
+			{
+				Name:      "ping",
+				Usage:     "tailcat ping [--until-direct] [--timeout=10s] <addrblob>",
+				ShortHelp: "ping a server, reporting DERP or direct paths",
+				Flags:     pingFS,
+				Exec: func(ctx context.Context, args []string) error {
+					return clientPingMode(getLogf(), *pingUntilDirect, *pingTimeout, args)
+				},
+			},
+			{
+				Name:      "socks",
+				Usage:     "tailcat socks [--listen=<addr:port>] [<addrblob>] [<cmd> [args...]]",
+				ShortHelp: "run a SOCKS5 proxy that dials tailcat servers",
+				Flags:     socksFS,
+				Exec: func(ctx context.Context, args []string) error {
+					return clientSOCKSMode(getLogf(), *socksListen, args)
+				},
+			},
+			sshCommand(rootFS),
+			{
+				Name:      "parse",
+				Usage:     "tailcat parse <addrblob>",
+				ShortHelp: "decode an address blob and print its fields as JSON",
+				Exec: func(ctx context.Context, args []string) error {
+					return clientParseMode(args)
+				},
+			},
+			{
+				Name:      "resolve",
+				Usage:     "tailcat resolve <addrblob>",
+				ShortHelp: "expand a short address blob to embed its DERP server info",
+				Exec: func(ctx context.Context, args []string) error {
+					return clientResolveMode(args)
+				},
+			},
+			{
+				Name:      "genkey",
+				Usage:     "tailcat genkey --key=<name> [--client] [--force] [--list] [--delete]",
+				ShortHelp: "generate, list, or delete saved keys",
+				Flags:     genkeyFS,
+				Exec: func(ctx context.Context, args []string) error {
+					return genKey(args)
+				},
+			},
+			{
+				Name:      "printpub",
+				Usage:     "tailcat printpub",
+				ShortHelp: "print the public key of the client key that would be used",
+				Exec: func(ctx context.Context, args []string) error {
+					fmt.Println(clientKey().Public().String())
+					return nil
+				},
+			},
+			{
+				Name:      "version",
+				Usage:     "tailcat version",
+				ShortHelp: "print the tailcat version (like --version)",
+				Exec: func(ctx context.Context, args []string) error {
+					fmt.Println(versionString())
+					return nil
+				},
+			},
+			{
+				Name:      "readme",
+				Usage:     "tailcat readme",
+				ShortHelp: "print the tailcat README (documentation with usage examples)",
+				Exec: func(ctx context.Context, args []string) error {
+					os.Stdout.WriteString(tailcat.README)
+					return nil
+				},
+			},
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) > 0 && args[0] == "help" {
+				return ff.ErrHelp
+			}
+			serverMode := len(args) == 0 || *flagServe != ""
+			if len(args) > 0 && serverMode {
+				return usagef("no positional arguments are valid along with --serve")
+			}
+			if serverMode {
+				server(getLogf())
+				return nil
+			}
+			if len(args) > 2 {
+				return usagef("too many arguments; client mode takes <addrblob> [<port>]")
+			}
+			var dst string
+			if len(args) == 2 {
+				dst = args[1]
+			}
+			return clientMode(getLogf(), string(addrBlobArg(args[0])), dst)
+		},
+	}
+}
+
+const rootLongHelp = `Server mode, accept one connection (any port), write to stdout:
 
 	tailcat
 
@@ -86,7 +240,7 @@ Server mode, exit node (clients can reach the server's whole network):
 
 	tailcat --serve=exit-node
 
-Client mode, to default port 0 for stdin/stdout pipe:
+Client mode, to default port 1 for stdin/stdout pipe:
 
 	echo hello | tailcat <addrblob>
 
@@ -141,15 +295,16 @@ Print the public key of the client key that would be used (see --key):
 	tailcat printpub
 
 Generate and save a persistent server key and print its address blob
-(run "tailcat genkey --help" for its flags):
+(run "tailcat genkey --help" for its flags). The key name "default"
+is magic: server mode uses it automatically once it exists:
 
-	tailcat genkey [--key=<name>] [--force]
+	tailcat genkey --key=default
 
 Generate and save a persistent client key and print its public key,
 for use in a server's --allow list. Client modes automatically use
 the key named "client-default" when it exists:
 
-	tailcat genkey --client
+	tailcat genkey --client --key=client-default
 
 List or delete saved keys:
 
@@ -158,25 +313,13 @@ List or delete saved keys:
 
 Print the full documentation (the project README) with more examples:
 
-	tailcat --readme
+	tailcat readme
 
 Environment:
 
 	TAILCAT_ADDR_FILE: in server mode, write the address blob to the
 	given file path or, with a "tcp:" prefix, send it to that TCP
-	address.
-
-Flags:
-
-`)
-	// Print the flag defaults with double hyphens (Go's single-hyphen
-	// style weirds people out, and the flag package accepts both).
-	var b strings.Builder
-	flag.CommandLine.SetOutput(&b)
-	flag.PrintDefaults()
-	os.Stderr.WriteString(strings.ReplaceAll("\n"+b.String(), "\n  -", "\n  --")[1:])
-	os.Exit(1)
-}
+	address.`
 
 // version is set via -ldflags by GoReleaser at release time.
 // It is empty for go-install and plain go-build builds.
@@ -194,57 +337,53 @@ func versionString() string {
 	return "unknown"
 }
 
+// usageError is an error caused by bad command line usage, as opposed
+// to a failure doing the requested work. main prints the selected
+// command's full help text along with it.
+type usageError struct{ error }
+
+// usagef returns a usageError whose message is the given
+// fmt.Sprintf-style arguments.
+func usagef(format string, args ...any) error {
+	return usageError{fmt.Errorf(format, args...)}
+}
+
 func main() {
-	flag.Usage = func() { usage("") }
-	flag.Parse()
-	if *flagReadme {
-		os.Stdout.WriteString(tailcat.README)
-		return
-	}
-	if *flagVersion {
-		fmt.Println(versionString())
-		return
-	}
-	if *flagVerbose {
-		tailcat.Verbose = true
-	}
-	args := flag.Args()
-	serverMode := len(args) == 0 || *flagServe != ""
-	if len(args) > 0 && serverMode {
-		usage("No positional arguments are valid along with --serve")
-	}
-	var logf logger.Logf = logger.Discard
-	if *flagVerbose {
-		logf = log.Printf
-	}
-	if serverMode {
-		server(logf)
-		return
-	}
-	switch args[0] {
-	case "help":
-		usage("")
-	case "ping":
-		clientPingMode(logf)
-	case "socks":
-		clientSOCKSMode(logf)
-	case "ssh":
-		clientSSHMode(logf)
-	case "parse":
-		clientParseMode(logf)
-	case "resolve":
-		clientResolveMode()
-	case "genkey":
-		genKey()
-	case "printpub":
-		fmt.Println(clientKey().Public().String())
-	default:
-		var dst string
-		if len(args) == 2 {
-			dst = args[1]
+	root := newRootCommand()
+	err := root.Parse(os.Args[1:])
+	if err == nil {
+		// The --version flag short-circuits everything else,
+		// including subcommand dispatch.
+		if *flagVersion {
+			fmt.Println(versionString())
+			return
 		}
-		clientMode(logf, string(addrBlobArg(args[0])), dst)
+		if *flagVerbose {
+			tailcat.Verbose = true
+		}
+		err = root.Run(context.Background())
 	}
+	if err == nil {
+		return
+	}
+	if errors.Is(err, ff.ErrHelp) {
+		// ffhelp.Command renders help for the subcommand selected
+		// during the parse, or for the root command if none was.
+		ffhelp.Command(root).WriteTo(os.Stderr)
+		os.Exit(0)
+	}
+	// Usage errors (including unknown flags) get the same help text
+	// as "tailcat <cmd> --help", with the error last, where it's
+	// visible under the scrollback.
+	var ue usageError
+	if errors.As(err, &ue) || errors.Is(err, ff.ErrUnknownFlag) {
+		ffhelp.Command(root).WriteTo(os.Stderr)
+		fmt.Fprintln(os.Stderr)
+	}
+	// No "tailcat:" prefix here: ff's parse errors already carry the
+	// command name, and exec errors read fine bare.
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
 }
 
 // addrBlobArg interprets a CLI destination argument as either a
@@ -365,26 +504,22 @@ func (c derpMapCache) Put(url string, data []byte, etag string) error {
 	return os.WriteFile(etagPath, []byte(etag), 0644)
 }
 
-func clientPingMode(logf logger.Logf) {
-	fs := flag.NewFlagSet("ping", flag.ExitOnError)
-	untilDirect := fs.Bool("until-direct", false, "keep pinging until a pong arrives over a direct (non-DERP) path; exit non-zero if that doesn't happen before --timeout")
-	timeout := fs.Duration("timeout", 10*time.Second, "give up after this long")
-	fs.Parse(flag.Args()[1:]) // stripping off "ping"
-	if len(fs.Args()) != 1 {
-		usage("tailcat ping [--until-direct] [--timeout=10s] <addrblob>")
+func clientPingMode(logf logger.Logf, untilDirect bool, timeout time.Duration, args []string) error {
+	if len(args) != 1 {
+		return usagef("ping requires one <addrblob> argument")
 	}
-	cl := newClient(logf, addrBlobArg(fs.Args()[0]), clientKey())
+	cl := newClient(logf, addrBlobArg(args[0]), clientKey())
 	defer cl.Close()
 
-	deadline := time.Now().Add(*timeout)
+	deadline := time.Now().Add(timeout)
 	for {
 		t0 := time.Now()
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		res, err := cl.DiscoPing(ctx)
 		cancel()
 		if err != nil {
-			if *untilDirect && errors.Is(err, context.DeadlineExceeded) {
-				log.Fatalf("no direct path to the server after %v", *timeout)
+			if untilDirect && errors.Is(err, context.DeadlineExceeded) {
+				log.Fatalf("no direct path to the server after %v", timeout)
 			}
 			log.Fatalf("ping: %v", err)
 		}
@@ -395,17 +530,17 @@ func clientPingMode(logf logger.Logf) {
 			via = fmt.Sprintf("DERP(%v)", cmp.Or(res.DERPRegionCode, res.DERPRegionID.String()))
 		}
 		fmt.Printf("pong in %v via %v\n", latency, via)
-		if direct || !*untilDirect {
-			return
+		if direct || !untilDirect {
+			return nil
 		}
 		if time.Until(deadline) < time.Second/2 {
-			log.Fatalf("no direct path to the server after %v", *timeout)
+			log.Fatalf("no direct path to the server after %v", timeout)
 		}
 		time.Sleep(max(0, time.Second-time.Since(t0)))
 	}
 }
 
-func clientMode(logf logger.Logf, connStr, optDest string) {
+func clientMode(logf logger.Logf, connStr, optDest string) error {
 	cl := newClient(logf, tailcat.ConnBlob(connStr), clientKey())
 
 	var dial func(context.Context) (net.Conn, error)
@@ -415,13 +550,13 @@ func clientMode(logf logger.Logf, connStr, optDest string) {
 	case !strings.Contains(optDest, ":"):
 		port, err := strconv.ParseUint(optDest, 10, 16)
 		if err != nil {
-			usage(fmt.Sprintf("invalid port number %q", optDest))
+			return usagef("invalid port number %q", optDest)
 		}
 		dial = func(ctx context.Context) (net.Conn, error) { return cl.DialTCPPort(ctx, uint16(port)) }
 	default:
 		addrPort, err := netip.ParseAddrPort(optDest)
 		if err != nil {
-			usage(fmt.Sprintf("invalid IP:port %q", optDest))
+			return usagef("invalid IP:port %q", optDest)
 		}
 		dial = func(ctx context.Context) (net.Conn, error) { return cl.DialTCP(ctx, addrPort) }
 	}
@@ -470,6 +605,7 @@ func clientMode(logf logger.Logf, connStr, optDest string) {
 	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer drainCancel()
 	cl.DrainTCP(drainCtx)
+	return nil
 }
 
 // normalizeListenAddrPort fills in the missing parts of the --listen
@@ -490,13 +626,8 @@ func normalizeListenAddrPort(s string) string {
 	return s + ":0"
 }
 
-func clientSOCKSMode(logf logger.Logf) {
-	fs := flag.NewFlagSet("socks", flag.ExitOnError)
-	listen := fs.String("listen", "127.0.0.1:0", "SOCKS5 proxy listen [address]:port; a bare port means localhost, a bare address means an OS-assigned port")
-	fs.Parse(flag.Args()[1:]) // stripping off "socks"
-	args := fs.Args()
-
-	listenAddrPort := normalizeListenAddrPort(*listen)
+func clientSOCKSMode(logf logger.Logf, listen string, args []string) error {
+	listenAddrPort := normalizeListenAddrPort(listen)
 
 	// The address blob argument is optional: destination hostnames that
 	// are themselves address blobs are dialed directly (see
@@ -591,6 +722,7 @@ func clientSOCKSMode(logf logger.Logf) {
 		log.Printf("SOCKS running at %v", socksAddr)
 		log.Fatalf("SOCKS5 server exited: %v", ss.Serve(socksLn))
 	}
+	return nil
 }
 
 // socksTarget is where a SOCKS5 destination address should be dialed.
@@ -653,32 +785,31 @@ func classifySOCKSAddr(ctx context.Context, lookup func(context.Context, string)
 	return socksTarget{dst: netip.AddrPortFrom(ip.Unmap(), uint16(portNum))}, nil
 }
 
-func clientParseMode(logf logger.Logf) {
-	args := flag.Args()
-	if len(args) != 2 {
-		usage("tailcat parse <addrblob>")
+func clientParseMode(args []string) error {
+	if len(args) != 1 {
+		return usagef("parse requires one <addrblob> argument")
 	}
-	v, err := tailcat.ParseConnBlobRaw(tailcat.ConnBlob(args[1]))
+	v, err := tailcat.ParseConnBlobRaw(tailcat.ConnBlob(args[0]))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	e := json.NewEncoder(os.Stdout)
 	e.SetIndent("", "    ")
-	e.Encode(v)
+	return e.Encode(v)
 }
 
-func clientResolveMode() {
-	args := flag.Args()
-	if len(args) != 2 {
-		usage("tailcat resolve <addrblob>")
+func clientResolveMode(args []string) error {
+	if len(args) != 1 {
+		return usagef("resolve requires one <addrblob> argument")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	rb, err := addrBlobArg(args[1]).Resolve(ctx, tailcat.DERPMapURL(*flagDERPMapURL), derpMapCache{})
+	rb, err := addrBlobArg(args[0]).Resolve(ctx, tailcat.DERPMapURL(*flagDERPMapURL), derpMapCache{})
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	fmt.Println(rb)
+	return nil
 }
 
 func server(logf logger.Logf) {
@@ -1035,80 +1166,73 @@ func keyPath(name string) string {
 	return filepath.Join(confDir, "tailcat", "keys", name+".private.json")
 }
 
-func genKey() {
+func genKey(args []string) error {
 	if *flagKey != "" {
-		log.Fatalf("genkey's --key argument must be after \"genkey\"")
+		return usagef("genkey's --key argument must be after \"genkey\"")
 	}
-	args := flag.Args()
-	fs := flag.NewFlagSet("genkey", flag.ExitOnError)
+	if len(args) > 0 {
+		return usagef("genkey takes no positional arguments")
+	}
 
 	confDir, err := os.UserConfigDir()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	var (
-		key          = fs.String("key", "", "key path (if it contains a slash) or name (written to "+confDir+"/tailcat/keys/<name>.private.json). If empty, 'default' is used, or 'client-default' with --client.")
-		client       = fs.Bool("client", false, "generate a client identity key (no DERP region) and print its public key, for use with servers' --allow lists. The 'client-default' key is used automatically by client modes.")
-		force        = fs.Bool("force", false, "force overwrite of existing key")
-		delete       = fs.Bool("delete", false, "delete the key named by --key instead of generating one; --key is required and must be a name, not a path")
-		list         = fs.Bool("list", false, "list saved key names and exit")
-		region       = fs.String("region", "auto", "region ID, code, or substring to use. Or a hostname(s) comma-separated to use a custom DERP server(s). If 'auto', one is picked based on latency at each server startup. If 'list', list all regions.")
-		fixedRegion  = fs.Bool("fixed-region", false, "discover the nearest DERP region once, now, and bake it into the key and token, so future server startups (and clients) use it without re-probing")
-		embedDERPMap = fs.Bool("embed-derp-map", false, "embed the DERP map nodes in the connection string")
+		key          = genkeyKey
+		client       = genkeyClient
+		force        = genkeyForce
+		delete       = genkeyDelete
+		list         = genkeyList
+		region       = genkeyRegion
+		fixedRegion  = genkeyFixedRegion
+		embedDERPMap = genkeyEmbedDERPMap
 	)
-	fs.Parse(args[1:]) // stripping off "genkey"
-	switch len(fs.Args()) {
-	case 0:
-	default:
-		fmt.Fprintf(os.Stderr, "tailcat genkey [--client] [--key=<name>] [--force]\n")
-		os.Exit(1)
+	// isSet reports whether the named genkey flag was set explicitly,
+	// as opposed to holding its default value.
+	isSet := func(name string) bool {
+		f, ok := genkeyFS.GetFlag(name)
+		return ok && f.IsSet()
 	}
 	if *list {
 		ents, err := os.ReadDir(filepath.Join(confDir, "tailcat", "keys"))
 		if err != nil && !os.IsNotExist(err) {
-			log.Fatal(err)
+			return err
 		}
 		for _, e := range ents {
 			if name, ok := strings.CutSuffix(e.Name(), ".private.json"); ok {
 				fmt.Println(name)
 			}
 		}
-		return
+		return nil
 	}
 	if *delete {
 		if *key == "" {
-			log.Fatalf("genkey --delete requires saying which key to delete with --key=<name> (see genkey --list)")
+			return usagef("genkey --delete requires saying which key to delete with --key=<name> (see genkey --list)")
 		}
 		if keyIsPath(*key) {
-			log.Fatalf("can't delete key %q; it's a path", *key)
+			return usagef("can't delete key %q; it's a path", *key)
 		}
-		if err := os.Remove(keyPath(*key)); err != nil {
-			log.Fatal(err)
-		}
-		return
+		return os.Remove(keyPath(*key))
 	}
 	if *key == "" {
 		if *client {
-			*key = "client-default"
-		} else {
-			*key = "default"
+			return usagef("genkey requires a --key=<name>; client modes automatically load the key named \"client-default\" when it exists, making it the usual choice")
 		}
+		return usagef("genkey requires a --key=<name>; server mode automatically loads the key named \"default\" when it exists, making it the usual choice")
 	}
 	if *client {
-		fs.Visit(func(f *flag.Flag) {
-			switch f.Name {
-			case "region", "fixed-region", "embed-derp-map":
-				log.Fatalf("genkey --client does not take --%s; client keys have no DERP region", f.Name)
+		for _, name := range []string{"region", "fixed-region", "embed-derp-map"} {
+			if isSet(name) {
+				return usagef("genkey --client does not take --%s; client keys have no DERP region", name)
 			}
-		})
+		}
 	}
 	if *fixedRegion {
-		fs.Visit(func(f *flag.Flag) {
-			if f.Name == "region" {
-				log.Fatalf("genkey --fixed-region and --region are mutually exclusive")
-			}
-		})
+		if isSet("region") {
+			return usagef("genkey --fixed-region and --region are mutually exclusive")
+		}
 		// The empty region means "pick the best region now", below.
 		*region = ""
 	}
@@ -1138,7 +1262,7 @@ func genKey() {
 		}
 		fmt.Fprintf(os.Stderr, "# wrote file to %v\n", *key)
 		fmt.Println(priv.Private.Public().String())
-		return
+		return nil
 	}
 
 	var match string
@@ -1218,6 +1342,7 @@ func genKey() {
 	}
 	fmt.Fprintf(os.Stderr, "# wrote file to %v\n", *key)
 	fmt.Println(priv.Public.ConnBlob())
+	return nil
 }
 
 // or returns 0 on no match

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/google/go-cmp v0.7.0
 	github.com/klauspost/compress v1.19.1
+	github.com/peterbourgon/ff/v4 v4.0.0-beta.1
 	github.com/tailscale/gliderssh v0.3.4-0.20260716005906-1a0f895faf28
 	github.com/u-root/u-root v0.14.0
 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,11 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml/v2 v2.2.0 h1:QLgLl2yMN7N+ruc31VynXs1vhMZa7CeHHejIeBAsoHo=
+github.com/pelletier/go-toml/v2 v2.2.0/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/peterbourgon/ff/v4 v4.0.0-beta.1 h1:hV8qRu3V7YfiSMsBSfPfdcznAvPQd3jI5zDddSrDoUc=
+github.com/peterbourgon/ff/v4 v4.0.0-beta.1/go.mod h1:onQJUKipvCyFmZ1rIYwFAh1BhPOvftb1uhvSI7krNLc=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=

--- a/readme.go
+++ b/readme.go
@@ -6,8 +6,8 @@ package tailcat
 import _ "embed"
 
 // README is the tailcat README.md, embedded so the CLI can print it
-// with its --readme flag. That lets people (and AI agents) with only
-// the binary learn how to use it without web access.
+// with its readme subcommand. That lets people (and AI agents) with
+// only the binary learn how to use it without web access.
 //
 //go:embed README.md
 var README string


### PR DESCRIPTION
The subcommand and flag handling was hand-rolled: a switch on the
first positional argument, per-subcommand flag.FlagSets buried in the
mode functions, a manual "-p" parse in the ssh subcommand, and a
hand-maintained usage string with no way to show subcommand flags.

Replace it with a github.com/peterbourgon/ff/v4 command tree. Each
subcommand now declares its flags, usage line, and short help, so
--help works at every level and renders the full flag list with
double-hyphen names, with the old examples text kept as the root
command's long help. Global flags keep working before the subcommand
name and, via flag set parenting, now also work after it. ff stops
parsing at the first non-flag argument, so trailing command args to
ssh and socks still pass through unparsed; cli_test.go locks that and
the rest of the argument surface down. The ts_omit_ssh build now
registers a stub ssh subcommand that errors instead of exiting via a
stub clientSSHMode.

While there, refresh the help text: a new one-line description, a
"version" subcommand as an alias for --version, a "readme" subcommand
replacing the --readme flag, and corrections for two stale claims (an
empty --serve accepts one connection on any port rather than
listening on port 0, and the client pipe default is port 1; see
CLEANUP.md's open 0-vs-1 item).

Behavior changes: bad usage (wrong arguments, unknown flags) now
prints the selected subcommand's full help, same as "tailcat <cmd>
--help", with the error last, and still exits 1; an explicit help
request (-h, --help, or "help") exits 0 instead of 1; single-dash
long flags (-serve=all) are no longer accepted, though the
documentation has only ever shown the double-hyphen form; and genkey
now requires a --key=<name> rather than silently writing a key named
"default" (or "client-default") to disk, since creating a persistent
key the user didn't clearly ask for is too big an action for a
default. The magic "default" and "client-default" names are now
documented in the flag help and README examples instead.
