### PR TITLE
cmd/tailcat: add a serve subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $
 Or you can serve a local TCP port, forwarded to localhost:
 
 ```sh
-$ tailcat --serve=8080,8443 # or --serve=all
+$ tailcat serve 8080,8443 # or: tailcat serve all
 # 🐈 Server listening with new address: tcXXXXXXXXX
 ```
 
@@ -149,10 +149,10 @@ HTTP/1.1 200 OK
 
 ### Auth-free SSH server
 
-On Linux and macOS, you can run an SSH server too with no auth. (If you want auth, you can just `tailcat --serve=22` and proxy to your system SSH server)
+On Linux and macOS, you can run an SSH server too with no auth. (If you want auth, you can just `tailcat serve 22` and proxy to your system SSH server)
 
 ```sh
-$ tailcat --serve=no-auth-ssh
+$ tailcat serve no-auth-ssh
 # 🐈 Server listening with new address: tcXXXXXXXXX
 ```
 
@@ -194,7 +194,7 @@ $ tailcat socks curl http://<token>:8081/
 Act as an exit node so the client can reach the server's network:
 
 ```sh
-$ tailcat --serve=exit-node
+$ tailcat serve exit-node
 ```
 
 Parse a connection token and print its contents (the server's WireGuard
@@ -238,7 +238,7 @@ $ tailcat parse tcomFwWCCcjS5nKNqAod034nWoJZW0LZqDhhC8U_dKdnDRYQ8uNGFygaFhToGjYW
 ```
 
 A server can print the long self-contained form directly with the
-`--full-address` flag.
+`tailcat serve --full-address` flag.
 
 ## Key Management
 
@@ -253,7 +253,8 @@ the key you use determines who can reach you:
 * **Saved keys:** `tailcat genkey` generates a key saved to disk so the
   address stays stable across restarts. The flip side: anyone you've *ever*
   shared that address with can connect to any future server using that key,
-  unless you restrict clients with `--allow` (see `tailcat genkey --client`).
+  unless you restrict clients with `tailcat serve --allow` (see
+  `tailcat genkey --client`).
 
 The CLI says at startup which kind it's using, so you know whether you're
 starting a fresh single-use server or re-listening on an address you may
@@ -264,11 +265,11 @@ $ tailcat genkey --key=default --region=nyc
 # prints the token; key saved to ~/.config/tailcat/keys/default.private.json
 
 # later; the key named "default" is used automatically once it exists:
-$ tailcat --serve=8080
+$ tailcat serve 8080
 # 🐈 Server listening with saved key "default": tcXXXXXXXXX
 
 # ... unless you force a one-off ephemeral key:
-$ tailcat --serve=8080 --key=new
+$ tailcat serve --key=new 8080
 # 🐈 Server listening with new address: tcXXXXXXXXX
 ```
 
@@ -315,7 +316,7 @@ server$ tailcat genkey --key=default --fixed-region
 # wrote file to ~/.config/tailcat/keys/default.private.json
 tcXXXXXXXXX
 
-server$ tailcat --serve=22 --allow=nodekey:cfb6bf...ddfd16
+server$ tailcat serve --allow=nodekey:cfb6bf...ddfd16 22
 # 🐈 Server listening with saved key "default": tcXXXXXXXXX
 ```
 
@@ -361,7 +362,7 @@ passing its hostname (or several, comma-separated) as the region:
 server$ tailcat genkey --key=default --region=derp.example.com
 tcomFwWCCAIsKOqPUux6ClG2RM4A_vOq4VBzGgHGGjq9OsJuFKSWFygaFhToGhYWhwZGVycC5leGFtcGxlLmNvbQ
 
-server$ tailcat --serve=22
+server$ tailcat serve 22
 ```
 
 The token embeds your relay's hostname:
@@ -468,7 +469,7 @@ followed by base64-encoded [CBOR](https://cbor.io/) containing:
 - A separate path-discovery public key (Curve25519, 32 bytes)
 - DERP info. Either:
   1. a small integer referencing one of the default [Tailscale-run tailcat servers](https://tailcat.dev/derpmap.json), or
-  2. full DERP server metadata, to either use a custom DERP server, or to avoid the client needing a potential round-trip to fetch the latest DERP map (the server's `--full-address` flag and the `tailcat resolve` subcommand produce this form)
+  2. full DERP server metadata, to either use a custom DERP server, or to avoid the client needing a potential round-trip to fetch the latest DERP map (the `tailcat serve --full-address` flag and the `tailcat resolve` subcommand produce this form)
 
 A typical token with just an integer region ID is around 95 bytes. With embedded
 DERP node details it's longer but self-contained.

--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -20,9 +20,9 @@ import (
 func TestHelpListsCommandTree(t *testing.T) {
 	help := ffhelp.Command(newRootCommand()).String()
 	for _, want := range []string{
-		"ping", "socks", "ssh", "parse", "resolve", "genkey", "printpub",
-		"version", "readme",
-		"--serve", "--key", "--allow", "--derpmap-url", "--full-address",
+		"serve", "ping", "socks", "ssh", "parse", "resolve", "genkey",
+		"printpub", "version", "readme",
+		"--serve", "--key", "--derpmap-url",
 	} {
 		if !strings.Contains(help, want) {
 			t.Errorf("root help is missing %q", want)
@@ -30,6 +30,35 @@ func TestHelpListsCommandTree(t *testing.T) {
 	}
 	if strings.Contains(help, "\n  -serve") {
 		t.Errorf("root help renders single-dash flags")
+	}
+	// Server-only flags live on the serve subcommand, not the root.
+	// (The long help prose may still mention them; only reject them
+	// as rendered flag entries.)
+	for _, notWant := range []string{"\n  --allow", "\n  --full-address"} {
+		if strings.Contains(help, notWant) {
+			t.Errorf("root help lists server-only flag %q", strings.TrimSpace(notWant))
+		}
+	}
+}
+
+// TestServeHelpListsServerFlags verifies that the server-only flags
+// moved off the root command render in the serve subcommand's help.
+func TestServeHelpListsServerFlags(t *testing.T) {
+	root := newRootCommand()
+	var serve *ff.Command
+	for _, sub := range root.Subcommands {
+		if sub.Name == "serve" {
+			serve = sub
+		}
+	}
+	if serve == nil {
+		t.Fatal("no serve subcommand")
+	}
+	help := ffhelp.Command(serve).String()
+	for _, want := range []string{"--allow", "--full-address", "--key"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("serve help is missing %q", want)
+		}
 	}
 }
 
@@ -39,6 +68,38 @@ func parseCLI(t *testing.T, args ...string) (root *ff.Command, err error) {
 	t.Helper()
 	root = newRootCommand()
 	return root, root.Parse(args)
+}
+
+// TestServeSubcommand verifies that the serve subcommand takes port
+// and service lists as positional arguments, accepts server flags,
+// and rejects mixing positional arguments with the --serve flag.
+func TestServeSubcommand(t *testing.T) {
+	root, err := parseCLI(t, "serve", "--key=new", "80,no-auth-ssh", "8000-8999")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel := root.GetSelected()
+	if sel.Name != "serve" {
+		t.Fatalf("selected command = %q; want serve", sel.Name)
+	}
+	if *flagKey != "new" {
+		t.Errorf("--key = %q; want new", *flagKey)
+	}
+	got := sel.Flags.(*ff.FlagSet).GetArgs()
+	want := []string{"80,no-auth-ssh", "8000-8999"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("leftover args = %q; want %q", got, want)
+	}
+
+	root, err = parseCLI(t, "serve", "--serve=80", "443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = root.Run(t.Context())
+	var ue usageError
+	if !errors.As(err, &ue) {
+		t.Errorf("serve --serve=80 443: err = %v; want a usageError", err)
+	}
 }
 
 // TestSSHTrailingArgs verifies that flag parsing stops at the ssh
@@ -151,6 +212,19 @@ func TestHelpGoesToStdout(t *testing.T) {
 	}
 	if stderr != "" {
 		t.Errorf("-h stderr = %q; want empty", stderr)
+	}
+
+	// A trailing --serve with no value gets the serve subcommand's
+	// help rather than ff's bare "missing value" parse error.
+	stdout, stderr, err = run("--serve")
+	if err != nil {
+		t.Fatalf("--serve: %v", err)
+	}
+	if !strings.Contains(stdout, "tailcat serve [flags]") {
+		t.Errorf("--serve stdout = %q; want serve help text", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("--serve stderr = %q; want empty", stderr)
 	}
 
 	stdout, stderr, err = run("genkey")

--- a/cmd/tailcat/serve_test.go
+++ b/cmd/tailcat/serve_test.go
@@ -68,9 +68,10 @@ func runClient(t *testing.T, client *exec.Cmd, payload string) (string, error) {
 	}
 }
 
-// TestServePorts verifies that a server with an explicit --serve port
-// list proxies connections on a served port to the same local port,
-// and refuses connections to ports outside the list.
+// TestServePorts verifies that a server with an explicit port list
+// (given to the serve subcommand) proxies connections on a served
+// port to the same local port, and refuses connections to ports
+// outside the list.
 func TestServePorts(t *testing.T) {
 	e := newTestEnv(t)
 	port := startEchoListener(t)
@@ -83,7 +84,7 @@ func TestServePorts(t *testing.T) {
 	unservedPort := ln.Addr().(*net.TCPAddr).Port
 	ln.Close()
 
-	_, blob, _ := e.startServer("--serve=" + strconv.Itoa(int(port)))
+	_, blob, _ := e.startServer("serve", strconv.Itoa(int(port)))
 
 	const payload = "echo through a served port"
 	got, err := runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, blob, strconv.Itoa(int(port))), payload)

--- a/cmd/tailcat/socks_test.go
+++ b/cmd/tailcat/socks_test.go
@@ -156,7 +156,7 @@ func TestSOCKSClientKey(t *testing.T) {
 	}
 	cpub := strings.TrimSpace(string(pub))
 
-	_, blob, _ := e.startServer("--serve=all", "--allow="+cpub)
+	_, blob, _ := e.startServer("serve", "--allow="+cpub, "all")
 
 	// The socks client pings the server before starting the proxy and
 	// exits non-zero if the ping fails, so a successful run of a

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -86,14 +86,16 @@ func getLogf() logger.Logf {
 // package-level flag value pointers.
 func newRootCommand() *ff.Command {
 	rootFS := ff.NewFlagSet("tailcat")
-	flagServe = rootFS.StringLong("serve", "", "comma-separated list of port numbers, port ranges, or service names to serve. Service names are: 'all' (serve all ports), 'exit-node' (run an exit node for all addresses), 'no-auth-ssh' (auth-free SSH server). If empty, it accepts a single connection on any port, writes it to stdout, and exits.")
+	flagServe = rootFS.StringLong("serve", "", "comma-separated list of port numbers, port ranges, or service names to serve; the same list the serve subcommand takes as arguments. Service names are: 'all' (serve all ports), 'exit-node' (run an exit node for all addresses), 'no-auth-ssh' (auth-free SSH server). If empty, it accepts a single connection on any port, writes it to stdout, and exits.")
 	flagKey = rootFS.StringLong("key", "", "'new' for an ephemeral key. If empty, the default saved key is used if it exists ('default' in server mode, 'client-default' in client modes; see genkey), else an ephemeral key. Otherwise the path to a *.private.json or a name like 'foo' to read it from $CONFIG/tailcat/keys/foo.private.json")
-	flagAllow = rootFS.StringLong("allow", "", "comma-separated list of public keys to allow access to the server, or 'none' to allow no clients. If empty, all clients are allowed.")
 	flagVerbose = rootFS.BoolLong("verbose", "be verbose")
 	flagVersion = rootFS.BoolLong("version", "print the tailcat version and exit")
-	flagFullAddress = rootFS.BoolLong("full-address", "in server mode, print a longer connection address token with embedded DERP server info instead of a reference to a DERP map region ID. This lets clients connect more quickly, without a DERP map fetch.")
 	flagJSON = rootFS.BoolLong("json", "in server mode, write {\"listenAddr\": ...} JSON to stdout")
 	flagDERPMapURL = rootFS.StringLong("derpmap-url", tailcat.DefaultDERPMapURL, "URL of the JSON DERP map used to resolve or auto-select a DERP region")
+
+	serveFS := ff.NewFlagSet("serve").SetParent(rootFS)
+	flagAllow = serveFS.StringLong("allow", "", "comma-separated list of public keys to allow access to the server, or 'none' to allow no clients. If empty, all clients are allowed.")
+	flagFullAddress = serveFS.BoolLong("full-address", "print a longer connection address token with embedded DERP server info instead of a reference to a DERP map region ID. This lets clients connect more quickly, without a DERP map fetch.")
 
 	pingFS := ff.NewFlagSet("ping").SetParent(rootFS)
 	pingUntilDirect := pingFS.BoolLong("until-direct", "keep pinging until a pong arrives over a direct (non-DERP) path; exit non-zero if that doesn't happen before --timeout")
@@ -123,6 +125,24 @@ func newRootCommand() *ff.Command {
 		LongHelp:  rootLongHelp,
 		Flags:     rootFS,
 		Subcommands: []*ff.Command{
+			{
+				Name:      "serve",
+				Usage:     "tailcat serve [flags] [<port,service,...> ...]",
+				ShortHelp: "run a server (the default when tailcat is run with no arguments)",
+				LongHelp:  serveLongHelp,
+				Flags:     serveFS,
+				Exec: func(ctx context.Context, args []string) error {
+					spec := *flagServe
+					if len(args) > 0 {
+						if spec != "" {
+							return usagef("use either --serve or positional port/service arguments, not both")
+						}
+						spec = strings.Join(args, ",")
+					}
+					server(getLogf(), spec)
+					return nil
+				},
+			},
 			{
 				Name:      "ping",
 				Usage:     "tailcat ping [--until-direct] [--timeout=10s] <addrblob>",
@@ -207,7 +227,7 @@ func newRootCommand() *ff.Command {
 				return usagef("no positional arguments are valid along with --serve")
 			}
 			if serverMode {
-				server(getLogf())
+				server(getLogf(), *flagServe)
 				return nil
 			}
 			if len(args) > 2 {
@@ -226,22 +246,22 @@ const rootLongHelp = `Server mode, accept one connection (any port), write to st
 
 	tailcat
 
-Server mode, given ports:
+Server mode, given ports (see "tailcat serve --help" for more):
 
-	tailcat --serve=22,80,443,8000-8999
+	tailcat serve 22,80,443,8000-8999
 
 Server mode, all ports:
 
-	tailcat --serve=all
+	tailcat serve all
 
 Server mode, certain ports and Tailscale SSH (auth without
 password or public key):
 
-	tailcat --serve=80,no-auth-ssh
+	tailcat serve 80,no-auth-ssh
 
 Server mode, exit node (clients can reach the server's whole network):
 
-	tailcat --serve=exit-node
+	tailcat serve exit-node
 
 Client mode, to default port 1 for stdin/stdout pipe:
 
@@ -289,7 +309,7 @@ Parse an address blob and print its encoded fields as JSON:
 	tailcat parse <addrblob>
 
 Resolve a short address blob into a longer self-contained one with
-embedded DERP server info (see also the server's --full-address flag):
+embedded DERP server info (see also serve's --full-address flag):
 
 	tailcat resolve <addrblob>
 
@@ -323,6 +343,52 @@ Environment:
 	TAILCAT_ADDR_FILE: in server mode, write the address blob to the
 	given file path or, with a "tcp:" prefix, send it to that TCP
 	address.`
+
+const serveLongHelp = `Run a tailcat server, printing its address blob for clients to
+connect to. Running tailcat with no arguments is the same as running
+"tailcat serve" with no arguments.
+
+The arguments are port numbers, port ranges, and service names,
+either as separate arguments or comma-separated. Ports are proxied
+to the same port on localhost. Service names are:
+
+	all          serve all ports
+	exit-node    run an exit node for all addresses
+	no-auth-ssh  auth-free SSH server (the tunnel provides identity)
+
+With no arguments, the server accepts a single connection on any
+port, writes it to stdout, and exits.
+
+Flags must come before the port and service arguments.
+
+Accept one connection, write it to stdout:
+
+	tailcat serve
+
+Serve some ports:
+
+	tailcat serve 22,80,443,8000-8999
+
+Serve all ports:
+
+	tailcat serve all
+
+Serve a port and the auth-free SSH server:
+
+	tailcat serve 80,no-auth-ssh
+
+Run an exit node (clients can reach the server's whole network):
+
+	tailcat serve exit-node
+
+Serve with a saved key (see genkey) and restrict clients:
+
+	tailcat serve --key=default --allow=nodekey:... 22
+
+Environment:
+
+	TAILCAT_ADDR_FILE: write the address blob to the given file
+	path or, with a "tcp:" prefix, send it to that TCP address.`
 
 const pingLongHelp = `Examples:
 
@@ -453,6 +519,19 @@ func main() {
 		// command if none was.
 		ffhelp.Command(root).WriteTo(os.Stdout)
 		os.Exit(0)
+	}
+	// A trailing --serve with no value is almost certainly someone
+	// asking what serving does, and ff's "missing value" error names
+	// neither the flag nor a fix. Treat it as a request for the serve
+	// subcommand's help. (A missing flag value can only be at the end
+	// of the arguments, so checking the last one suffices.)
+	if strings.Contains(err.Error(), "missing value") && os.Args[len(os.Args)-1] == "--serve" {
+		for _, sub := range root.Subcommands {
+			if sub.Name == "serve" {
+				ffhelp.Command(sub).WriteTo(os.Stdout)
+				os.Exit(0)
+			}
+		}
 	}
 	// Usage errors (including unknown flags) get the same help text
 	// as "tailcat <cmd> --help", with the error last, where it's
@@ -894,10 +973,10 @@ func clientResolveMode(args []string) error {
 	return nil
 }
 
-func server(logf logger.Logf) {
-	portSet, services, err := parsePortSet(*flagServe)
+func server(logf logger.Logf, serveSpec string) {
+	portSet, services, err := parsePortSet(serveSpec)
 	if err != nil {
-		log.Fatalf("invalid value in --serve: %v", err)
+		log.Fatalf("invalid port or service to serve: %v", err)
 	}
 
 	var reg *tailcfg.DERPRegion


### PR DESCRIPTION
Server flags had accumulated at the top level with no home of their
own. Add a serve subcommand that takes the --serve port/service list
as positional arguments and carries the server examples in its help.

Running tailcat with no arguments still serves, and the top-level
--serve flag keeps working, so existing invocations are unaffected;
the subcommand is the documented, discoverable form. The rarely used
--allow and --full-address flags do move under serve, though, and a
trailing --serve with no value now prints the serve help instead of
ff's bare "missing value" error.

Updates #40
