### PR TITLE
cmd/tailcat: fix accidental revert of pipe_test.go "none" DERP URL

### DIFF
--- a/cmd/tailcat/pipe_test.go
+++ b/cmd/tailcat/pipe_test.go
@@ -25,7 +25,7 @@ import (
 func TestLocalDERPMode(t *testing.T) {
 	bin := buildTailcat(t)
 
-	const derpMapURL = "http://127.0.0.1:9/unreachable"
+	const derpMapURL = "none"
 	addrFile := filepath.Join(t.TempDir(), "addr")
 
 	server := exec.Command(bin, "--key=new", "--derpmap-url="+derpMapURL)


### PR DESCRIPTION
In the Homebrew formula's test, I was using "none", so match, just
in case we start non-lazily parsing this.
