### PR TITLE
cmd/tailcat: omit an empty --key from the ssh ProxyCommand

### DIFF
--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -114,7 +114,13 @@ func sshProxyCommand(exe, keyName, derpMapURL, connBlob, portOrIPPort string) st
 		// and the child's own command line parsing.
 		exe = "\"" + exe + "\""
 	}
-	cmd := fmt.Sprintf("%s --key=%q", exe, keyName)
+	cmd := exe
+	// No --key flag at all when unset: the shell turns --key="" into
+	// --key=, which ff parses by consuming the next argument (the
+	// address blob) as the flag's value.
+	if keyName != "" {
+		cmd += fmt.Sprintf(" --key=%q", keyName)
+	}
 	if derpMapURL != tailcat.DefaultDERPMapURL {
 		cmd += fmt.Sprintf(" --derpmap-url=%q", derpMapURL)
 	}

--- a/cmd/tailcat/ssh_test.go
+++ b/cmd/tailcat/ssh_test.go
@@ -37,6 +37,15 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 	if got != want {
 		t.Errorf("sshProxyCommand with default DERP map = %q; want %q", got, want)
 	}
+
+	// No --key flag at all when unset. The shell would collapse
+	// --key="" to --key=, which ff parses by consuming the next
+	// argument, the address blob.
+	got = sshProxyCommand(exe, "", tailcat.DefaultDERPMapURL, blob, port)
+	want = wantExe + ` tc-short-blob 22`
+	if got != want {
+		t.Errorf("sshProxyCommand with no key = %q; want %q", got, want)
+	}
 }
 
 func TestSSHDestHost(t *testing.T) {


### PR DESCRIPTION
With no --key given, tailcat ssh put --key="" in the OpenSSH
ProxyCommand, which the shell collapses to --key=. ff parses an
empty =-form value by consuming the following argument as the flag's
value instead, so the proxy invocation ate its own address blob and
failed with 'argument "22" is neither a "tc"-prefixed address blob
nor a DNS name'. A regression from the ff/v4 port: the old flag
package parsed --key= as an empty string.

Leave the flag out entirely when it's unset.
