### PR TITLE
flake.nix, tool/updateflakes: keep the nix vendor hash fresh automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,17 @@ jobs:
       # long timeout. actions/setup-go's caches keep warm runs fast.
       - run: go test -count=1 -timeout 600s ./...
       - run: go vet ./...
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      # Fails if go.mod/go.sum or the nix flake vendor hash in
+      # flakehashes.json are stale; run `make tidy` to fix.
+      - run: make tidy
+      - run: git diff --name-only --exit-code
   release-tags:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # GoReleaser output.
 /dist
 
+# Nix build output.
+/result
+
 # Go test artifacts.
 *.test
 *.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+tidy: ## Run go mod tidy and update nix flake hashes
+	go mod tidy
+	go run ./tool/updateflakes
+
+.PHONY: tidy

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,9 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        # flakehashes.json is maintained by `make tidy`
+        # (tool/updateflakes); do not edit it by hand.
+        flakeHashes = builtins.fromJSON (builtins.readFile ./flakehashes.json);
         # go.mod requires Go 1.27, which is newer than the default
         # pkgs.go/buildGoModule as of 2026-08.
         buildGoModule = pkgs.buildGoModule.override { go = pkgs.go_1_27; };
@@ -20,7 +23,7 @@
           version = self.shortRev or "dev";
           src = self;
           subPackages = [ "cmd/tailcat" ];
-          vendorHash = "sha256-bCdCsYcoXQSSIe3aS73o7do+rbuNniPNw8yNwoEnH6A=";
+          vendorHash = flakeHashes.vendor.sri;
           meta = {
             description = "netcat over Tailscale's data plane, without its control plane";
             homepage = "https://github.com/tailscale/tailcat";
@@ -34,3 +37,4 @@
         };
       });
 }
+# nix-direnv cache busting line: sha256-lznT3EXFHsTS9nn7mVheWJw+2uDtsh1gljqEHxnbdso=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -1,0 +1,6 @@
+{
+  "vendor": {
+    "goModSum": "sha256-QB8SdTuhCENpZhUhLT3xl4LmagjedXJtan+s/8IdrAo=",
+    "sri": "sha256-lznT3EXFHsTS9nn7mVheWJw+2uDtsh1gljqEHxnbdso="
+  }
+}

--- a/tool/updateflakes/updateflakes.go
+++ b/tool/updateflakes/updateflakes.go
@@ -1,0 +1,173 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// updateflakes regenerates flakehashes.json, the file that records
+// the Nix SRI hash of the Go module vendor tree for flake.nix.
+//
+// The file is content-addressed: it records the go.mod/go.sum
+// fingerprint that produced the SRI, and updateflakes only
+// regenerates the hash when the current fingerprint differs from the
+// recorded one. As a result, repeat runs with no input changes are
+// no-ops.
+//
+// Run from the repo root:
+//
+//	go run ./tool/updateflakes
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+
+	"tailscale.com/cmd/nardump/nardump"
+)
+
+const (
+	hashesFile      = "flakehashes.json"
+	goModFile       = "go.mod"
+	goSumFile       = "go.sum"
+	flakeNixFile    = "flake.nix"
+	cacheBustPrefix = "# nix-direnv cache busting line:"
+)
+
+// FlakeHashes is the on-disk schema of flakehashes.json. It is also
+// consumed directly by flake.nix via builtins.fromJSON, so changes
+// to the JSON shape must be coordinated with flake.nix.
+type FlakeHashes struct {
+	Vendor VendorHash `json:"vendor"`
+}
+
+// VendorHash records the SRI of `go mod vendor` output. GoModSum is a
+// fingerprint of go.mod and go.sum that produced SRI.
+type VendorHash struct {
+	GoModSum string `json:"goModSum"`
+	SRI      string `json:"sri"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	have, err := loadHashes()
+	if err != nil {
+		return err
+	}
+	want := have
+
+	goModSum, err := goModFingerprint()
+	if err != nil {
+		return err
+	}
+	if have.Vendor.GoModSum != goModSum || have.Vendor.SRI == "" {
+		sri, err := hashVendor()
+		if err != nil {
+			return err
+		}
+		want.Vendor = VendorHash{GoModSum: goModSum, SRI: sri}
+	}
+
+	if want != have {
+		if err := writeHashes(want); err != nil {
+			return err
+		}
+	}
+
+	// nix-direnv only watches the top-level nix files for changes,
+	// so when a referenced hash changes we must also tickle
+	// flake.nix to force re-evaluation.
+	return updateCacheBust(flakeNixFile, want.Vendor.SRI)
+}
+
+func loadHashes() (FlakeHashes, error) {
+	var h FlakeHashes
+	data, err := os.ReadFile(hashesFile)
+	if errors.Is(err, fs.ErrNotExist) {
+		return h, nil
+	}
+	if err != nil {
+		return h, err
+	}
+	if err := json.Unmarshal(data, &h); err != nil {
+		return h, fmt.Errorf("parse %s: %w", hashesFile, err)
+	}
+	return h, nil
+}
+
+func writeHashes(h FlakeHashes) error {
+	b, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(hashesFile, b, 0644)
+}
+
+// goModFingerprint returns a content fingerprint of go.mod and go.sum
+// that changes whenever either file changes.
+func goModFingerprint() (string, error) {
+	h := sha256.New()
+	for _, f := range []string{goModFile, goSumFile} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%s %d\n", f, len(b))
+		h.Write(b)
+	}
+	return "sha256-" + base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+func hashVendor() (string, error) {
+	out, err := os.MkdirTemp("", "nar-vendor-")
+	if err != nil {
+		return "", err
+	}
+	// `go mod vendor -o` requires the destination to not already exist.
+	if err := os.Remove(out); err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(out)
+
+	cmd := exec.Command("go", "mod", "vendor", "-o", out)
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("go mod vendor: %w", err)
+	}
+	return nardump.SRI(os.DirFS(out))
+}
+
+// updateCacheBust rewrites the "# nix-direnv cache busting line"
+// in path to embed sri so nix-direnv re-evaluates when the SRI
+// changes. The line lives at end of file, so walk in reverse.
+func updateCacheBust(path, sri string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	want := []byte(cacheBustPrefix + " " + sri)
+	lines := bytes.Split(b, []byte("\n"))
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := lines[i]
+		if !bytes.HasPrefix(line, []byte(cacheBustPrefix)) {
+			continue
+		}
+		if bytes.Equal(line, want) {
+			return nil
+		}
+		lines[i] = want
+		return os.WriteFile(path, bytes.Join(lines, []byte("\n")), 0644)
+	}
+	return fmt.Errorf("%s: missing %q line", path, cacheBustPrefix)
+}


### PR DESCRIPTION
The flake hard-coded buildGoModule's vendorHash, and three go.mod
changes later it was stale, breaking nix build for anyone using the
flake.

Port tailscale.com's updateflakes tool (minus its custom toolchain
handling): "make tidy" runs go mod tidy and then recomputes the vendor
tree's SRI hash in pure Go via tailscale.com/cmd/nardump/nardump,
recording it in flakehashes.json, which flake.nix now reads with
builtins.fromJSON. The JSON also records a go.mod/go.sum fingerprint
so repeat runs are no-ops, and a cache busting line in flake.nix makes
nix-direnv re-evaluate when the hash changes.

A new tidy CI job runs "make tidy" and fails on any resulting diff, so
a PR that changes dependencies without refreshing the hash can't land.
No nix is required on the CI runner.

Fixes #53
