### PR TITLE
tailcat: add --auto-region to find a server that moved DERP region

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,13 +422,25 @@ name a fixed region so clients and future server restarts all
 rendezvous in the same place. (`--region=<name>` pins an explicit one
 instead; `--region=list` shows the choices.)
 
-If a published token does go stale (the server moved, or the DERP map
-changed), pass `--auto-region` on the client. It searches the current
-map for the same server and prints a corrected token on stderr so you
-can store it. That's a rescue, not a reason to publish `--region=auto`
-tokens; `--fixed-region` is still what you want for anything long-lived.
-The rest of https://github.com/tailscale/tailcat/issues/7 (a server
-in more than one region, lat/long in tokens) is still open.
+If a published address does go stale (the server moved, or the DERP
+map changed), pass `--auto-region` on the client. It searches the
+current map for the same server and prints a corrected address on
+stderr so you can store it. That's a rescue, not a reason to publish
+`--region=auto` addresses; `--fixed-region` is still what you want for
+anything long-lived. The rest of
+https://github.com/tailscale/tailcat/issues/7 (a server in more than
+one region, lat/long in addresses) is still open.
+
+The search covers every region the DERP map publishes, however many
+that grows to, probing eight at a time so a stale address costs a
+bounded number of connections rather than one per region. It works
+outward from the region the address names, since a server that re-picks
+by latency usually lands near where it was, and asks each relay
+outright whether it has the server, which is answered in a round trip
+rather than a timeout. Where it finds the server is remembered in
+`$XDG_CACHE_HOME/tailcat/regions.json`, so a moved server costs one
+search and not one per connection; deleting that file only costs
+another search.
 
 	tailcat ping --auto-region --verbose tcOLD…
 	tailcat ssh --auto-region tcOLD…

--- a/README.md
+++ b/README.md
@@ -422,8 +422,16 @@ name a fixed region so clients and future server restarts all
 rendezvous in the same place. (`--region=<name>` pins an explicit one
 instead; `--region=list` shows the choices.)
 
-TODO: make the client more robust here if the DERP map changes over
-time: https://github.com/tailscale/tailcat/issues/7
+If a published token does go stale (the server moved, or the DERP map
+changed), pass `--auto-region` on the client. It searches the current
+map for the same server and prints a corrected token on stderr so you
+can store it. That's a rescue, not a reason to publish `--region=auto`
+tokens; `--fixed-region` is still what you want for anything long-lived.
+The rest of https://github.com/tailscale/tailcat/issues/7 (a server
+in more than one region, lat/long in tokens) is still open.
+
+	tailcat ping --auto-region --verbose tcOLD…
+	tailcat ssh --auto-region tcOLD…
 
 ### Bring your own DERP relay
 

--- a/cmd/tailcat/autoregion_e2e_test.go
+++ b/cmd/tailcat/autoregion_e2e_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tailscale/tailcat"
+	"tailscale.com/tailcfg"
+	"tailscale.com/tstest/integration"
+)
+
+// twoRegionCLIEnv is a testEnv whose DERP map has two localhost
+// relays, as regions 1 and 2. --auto-region needs that: a stale
+// address names region 1 while the server is actually on 2.
+func twoRegionCLIEnv(t *testing.T) *testEnv {
+	t.Helper()
+	bin := buildTailcat(t)
+
+	a := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1")
+	b := integration.RunDERPAndSTUN(t, t.Logf, "127.0.0.1")
+	r1, r2 := a.Regions[1], b.Regions[1]
+	if r1 == nil || r2 == nil {
+		t.Fatal("no region 1 in a test DERP map")
+	}
+	r1.RegionName = "Test Region 1"
+	r2.RegionID, r2.RegionCode, r2.RegionName = 2, "test2", "Test Region 2"
+	for _, n := range r1.Nodes {
+		n.HostName = "t1.test"
+	}
+	for _, n := range r2.Nodes {
+		n.RegionID, n.Name, n.HostName = 2, "t2", "t2.test"
+	}
+	dm := &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{1: r1, 2: r2}}
+	dmJSON, err := json.Marshal(dm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(dmJSON)
+	}))
+	t.Cleanup(dmSrv.Close)
+
+	return &testEnv{
+		t:          t,
+		bin:        bin,
+		derpMapURL: dmSrv.URL,
+		env:        append(os.Environ(), cacheEnv(t)...),
+	}
+}
+
+func staleRegionAddr(t *testing.T, addr string, region tailcfg.DERPRegionID) string {
+	t.Helper()
+	ci, err := tailcat.ParseAddr(tailcat.Addr(addr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ci.Region, ci.RegionID = nil, region
+	return string(ci.Addr())
+}
+
+func runPing(t *testing.T, e *testEnv, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := e.cmd(args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-done:
+		case <-time.After(90 * time.Second):
+			cmd.Process.Kill()
+		}
+	}()
+	err = cmd.Run()
+	close(done)
+	return outBuf.String(), errBuf.String(), err
+}
+
+// TestAutoRegionPing is the CLI acceptance test for --auto-region:
+// a server bound to region 2, an address rewritten to name region 1,
+// then ping without the flag (must fail) and with it (must find the
+// server, print a pong on stdout, and put the corrected address on
+// stderr).
+func TestAutoRegionPing(t *testing.T) {
+	e := twoRegionCLIEnv(t)
+
+	keyFile := filepath.Join(t.TempDir(), "server.private.json")
+	gen := e.cmd("--derpmap-url="+e.derpMapURL, "genkey", "--key="+keyFile, "--region=2")
+	if out, err := gen.CombinedOutput(); err != nil {
+		t.Fatalf("genkey --region=2: %v\n%s", err, out)
+	}
+
+	_, addr, _ := e.startServer("--key=" + keyFile)
+	ci, err := tailcat.ParseAddr(tailcat.Addr(addr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ci.RegionID != 2 {
+		t.Fatalf("server address RegionID = %v; want 2", ci.RegionID)
+	}
+	stale := staleRegionAddr(t, addr, 1)
+
+	stdout, stderr, err := runPing(t, e, "--key=new", "--derpmap-url="+e.derpMapURL, "ping", "--timeout=5s", stale)
+	if err == nil {
+		t.Fatalf("ping without --auto-region succeeded; want failure\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	stdout, stderr, err = runPing(t, e, "--key=new", "--derpmap-url="+e.derpMapURL, "--auto-region", "--verbose", "ping", stale)
+	if err != nil {
+		t.Fatalf("ping --auto-region: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	// stdout is the ProxyCommand tunnel in the other client modes, so
+	// nothing about the search may appear on it.
+	if !strings.Contains(stdout, "pong") {
+		t.Errorf("stdout = %q; want a pong line", stdout)
+	}
+	if strings.Contains(stdout, "auto-region") || strings.Contains(stdout, "region 2") {
+		t.Errorf("stdout = %q; the region notice must go to stderr", stdout)
+	}
+	if !strings.Contains(stderr, "region 2") {
+		t.Errorf("stderr = %q; want the corrected region 2 notice", stderr)
+	}
+	if !strings.Contains(stderr, "its current address is:") {
+		t.Errorf("stderr = %q; want the corrected address", stderr)
+	}
+	if !strings.Contains(stderr, "auto-region:") {
+		t.Errorf("verbose stderr = %q; want per-region auto-region progress", stderr)
+	}
+}

--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -207,8 +207,8 @@ func TestSocksTrailingArgs(t *testing.T) {
 // it (via flag set parenting).
 func TestGlobalFlagPlacement(t *testing.T) {
 	for _, args := range [][]string{
-		{"--key=new", "--derpmap-url=http://d/", "ping", "--timeout=5s", "tcaddr"},
-		{"ping", "--key=new", "--derpmap-url=http://d/", "--timeout=5s", "tcaddr"},
+		{"--key=new", "--derpmap-url=http://d/", "--auto-region", "ping", "--timeout=5s", "tcaddr"},
+		{"ping", "--key=new", "--derpmap-url=http://d/", "--auto-region", "--timeout=5s", "tcaddr"},
 	} {
 		if _, err := parseCLI(t, args...); err != nil {
 			t.Fatalf("parse %q: %v", args, err)
@@ -218,6 +218,9 @@ func TestGlobalFlagPlacement(t *testing.T) {
 		}
 		if *flagDERPMapURL != "http://d/" {
 			t.Errorf("parse %q: --derpmap-url = %q; want http://d/", args, *flagDERPMapURL)
+		}
+		if !*flagAutoRegion {
+			t.Errorf("parse %q: --auto-region = false; want true", args)
 		}
 	}
 }

--- a/cmd/tailcat/cp.go
+++ b/cmd/tailcat/cp.go
@@ -104,7 +104,7 @@ func clientCPMode(recursive, preserve bool, portOrIPPort string, args []string) 
 	if err != nil {
 		log.Fatalf("no scp found in $PATH: %v", err)
 	}
-	proxyCommand, err := sshProxyCommand(exe, *flagKey, *flagDERPMapURL, addr, portOrIPPort)
+	proxyCommand, err := sshProxyCommand(exe, proxyFlags(), addr, portOrIPPort)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailcat/files_e2e_test.go
+++ b/cmd/tailcat/files_e2e_test.go
@@ -21,7 +21,7 @@ import (
 // commands, returning its combined output and error.
 func runSFTPBatch(t *testing.T, e *testEnv, addr, batch string) ([]byte, error) {
 	t.Helper()
-	proxyCommand, err := sshProxyCommand(e.bin, "new", e.derpMapURL, addr, "22")
+	proxyCommand, err := sshProxyCommand(e.bin, proxyOpts{keyName: "new", derpMapURL: e.derpMapURL}, addr, "22")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/tailcat/ls.go
+++ b/cmd/tailcat/ls.go
@@ -64,7 +64,11 @@ func clientLSMode(logf logger.Logf, long bool, args []string) error {
 	cl := newClient(logf, tailcatAddrArg(host), clientKey())
 	defer cl.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	timeout := 30 * time.Second
+	if *flagAutoRegion {
+		timeout = autoRegionTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	conn, err := cl.DialTCPPort(ctx, 22)
 	if err != nil {

--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -94,7 +94,7 @@ func clientSSHMode(portOrIPPort string, args []string) error {
 	if sshUser != "" {
 		sshDst = sshUser + "@" + sshDst
 	}
-	proxyCommand, err := sshProxyCommand(exe, *flagKey, *flagDERPMapURL, addrStr, portOrIPPort)
+	proxyCommand, err := sshProxyCommand(exe, proxyFlags(), addrStr, portOrIPPort)
 	if err != nil {
 		return err
 	}
@@ -142,18 +142,38 @@ func validatedAddr(arg string) (string, error) {
 	return string(addr), nil
 }
 
+// proxyOpts are the global tailcat flags that a ProxyCommand has to
+// carry into the child process, which is the one that actually connects.
+type proxyOpts struct {
+	keyName    string
+	derpMapURL string
+	autoRegion bool
+}
+
+// proxyFlags returns the global flags as given on this invocation.
+func proxyFlags() proxyOpts {
+	return proxyOpts{
+		keyName:    *flagKey,
+		derpMapURL: *flagDERPMapURL,
+		autoRegion: *flagAutoRegion,
+	}
+}
+
 // sshProxyCommand returns the command passed to OpenSSH to connect the SSH
 // client to a tailcat server. The command is run by OpenSSH, so values that
 // can contain shell-special characters must be quoted.
-func sshProxyCommand(exe, keyName, derpMapURL, addr, portOrIPPort string) (string, error) {
+func sshProxyCommand(exe string, o proxyOpts, addr, portOrIPPort string) (string, error) {
 	args := []string{exe}
 	// No --key flag at all when unset: ff parses --key= by consuming the
 	// tailcat address as the flag's value.
-	if keyName != "" {
-		args = append(args, "--key="+keyName)
+	if o.keyName != "" {
+		args = append(args, "--key="+o.keyName)
 	}
-	if derpMapURL != tailcat.DefaultDERPMapURL {
-		args = append(args, "--derpmap-url="+derpMapURL)
+	if o.derpMapURL != tailcat.DefaultDERPMapURL {
+		args = append(args, "--derpmap-url="+o.derpMapURL)
+	}
+	if o.autoRegion {
+		args = append(args, "--auto-region")
 	}
 	args = append(args, addr, portOrIPPort)
 	if runtime.GOOS == "windows" {

--- a/cmd/tailcat/ssh_test.go
+++ b/cmd/tailcat/ssh_test.go
@@ -44,7 +44,7 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 		port = "22"
 		url  = "https://derp.example.com/derpmap.json"
 	)
-	got, err := sshProxyCommand(exe, key, url, addr, port)
+	got, err := sshProxyCommand(exe, proxyOpts{keyName: key, derpMapURL: url}, addr, port)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 		t.Errorf("sshProxyCommand with custom DERP map = %q; want %q", got, want)
 	}
 
-	got, err = sshProxyCommand(exe, key, tailcat.DefaultDERPMapURL, addr, port)
+	got, err = sshProxyCommand(exe, proxyOpts{keyName: key, derpMapURL: tailcat.DefaultDERPMapURL}, addr, port)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 	// No --key flag at all when unset. The shell would collapse
 	// --key="" to --key=, which ff parses by consuming the next
 	// argument, the tailcat address.
-	got, err = sshProxyCommand(exe, "", tailcat.DefaultDERPMapURL, addr, port)
+	got, err = sshProxyCommand(exe, proxyOpts{derpMapURL: tailcat.DefaultDERPMapURL}, addr, port)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,6 +81,20 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("sshProxyCommand with no key = %q; want %q", got, want)
+	}
+
+	// --auto-region has to reach the child: it, not the ssh process,
+	// is what connects.
+	got, err = sshProxyCommand(exe, proxyOpts{derpMapURL: tailcat.DefaultDERPMapURL, autoRegion: true}, addr, port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = `'` + exe + `' '--auto-region' 'tc-short-addr' '22'`
+	if runtime.GOOS == "windows" {
+		want = `"/path/to/tailcat" "--auto-region" "tc-short-addr" "22"`
+	}
+	if got != want {
+		t.Errorf("sshProxyCommand with auto-region = %q; want %q", got, want)
 	}
 }
 

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -765,6 +765,7 @@ func newClient(logf logger.Logf, addr tailcat.Addr, priv key.NodePrivate) *tailc
 		DERPMapURL:   *flagDERPMapURL,
 		DERPMapCache: derpMapCache{},
 		AutoRegion:   *flagAutoRegion,
+		RegionCache:  regionCache{},
 		// Stderr, not stdout: in client mode stdout is the connection
 		// itself, which ssh and scp use as a ProxyCommand.
 		OnRegionDiscovered: func(cur tailcat.Addr, r *tailcfg.DERPRegion) {
@@ -826,6 +827,128 @@ func (c derpMapCache) Put(url string, data []byte, etag string) error {
 		return nil
 	}
 	return os.WriteFile(etagPath, []byte(etag), 0644)
+}
+
+const (
+	// regionCacheMaxAge drops entries for servers not reached in a long
+	// time, so a file that is only ever added to doesn't grow forever.
+	regionCacheMaxAge = 30 * 24 * time.Hour
+
+	// regionCacheMaxEntries bounds the file for a client that reaches
+	// more servers than that within regionCacheMaxAge.
+	regionCacheMaxEntries = 256
+)
+
+// regionCache implements [tailcat.RegionCache] on disk, in
+// $XDG_CACHE_HOME/tailcat/regions.json: one JSON object mapping a
+// server's node key to the DERP region a search last found it in, so
+// that a moved server costs one search rather than one per connection.
+// ssh and cp re-exec tailcat per session, so without this the same
+// search runs again for every one of them.
+//
+// A wrong entry is self-correcting: it is probed alongside the region
+// the address names, so it costs one extra probe and the search that
+// follows overwrites it. That's why entries have no freshness check,
+// only a bound on how many accumulate.
+type regionCache struct{}
+
+type regionCacheEntry struct {
+	RegionID tailcfg.DERPRegionID `json:"r"`
+	At       time.Time            `json:"t"`
+}
+
+// regionCacheMu keeps concurrent calls in one process from clobbering
+// each other's read-modify-write. Separate processes can still lose an
+// entry, which costs one search and is repaired by the next one.
+var regionCacheMu sync.Mutex
+
+func regionCachePath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "tailcat", "regions.json"), nil
+}
+
+// readRegionCache returns the stored entries, or an empty map if the
+// file is missing or unreadable: it's a cache, so a bad one only costs
+// the search it would have saved.
+func readRegionCache() map[string]regionCacheEntry {
+	path, err := regionCachePath()
+	if err != nil {
+		return nil
+	}
+	j, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var m map[string]regionCacheEntry
+	if err := json.Unmarshal(j, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func (regionCache) GetRegion(serverPub key.NodePublic) (tailcfg.DERPRegionID, bool) {
+	regionCacheMu.Lock()
+	defer regionCacheMu.Unlock()
+	e, ok := readRegionCache()[serverPub.String()]
+	if !ok || e.RegionID <= 0 {
+		return 0, false
+	}
+	return e.RegionID, true
+}
+
+func (regionCache) PutRegion(serverPub key.NodePublic, regionID tailcfg.DERPRegionID) error {
+	regionCacheMu.Lock()
+	defer regionCacheMu.Unlock()
+	path, err := regionCachePath()
+	if err != nil {
+		return err
+	}
+	m := readRegionCache()
+	if m == nil {
+		m = map[string]regionCacheEntry{}
+	}
+	m[serverPub.String()] = regionCacheEntry{RegionID: regionID, At: time.Now()}
+
+	cutoff := time.Now().Add(-regionCacheMaxAge)
+	for k, e := range m {
+		if e.At.Before(cutoff) {
+			delete(m, k)
+		}
+	}
+	if len(m) > regionCacheMaxEntries {
+		oldest := slices.SortedFunc(maps.Keys(m), func(a, b string) int {
+			return m[a].At.Compare(m[b].At)
+		})
+		for _, k := range oldest[:len(m)-regionCacheMaxEntries] {
+			delete(m, k)
+		}
+	}
+
+	j, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	// Written whole and renamed into place: a torn file would read back
+	// as an empty cache, silently costing a search on every connection.
+	tmp, err := os.CreateTemp(filepath.Dir(path), "regions-*.json")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(j); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
 }
 
 func clientPingMode(logf logger.Logf, untilDirect bool, timeout time.Duration, args []string) error {

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -58,6 +58,7 @@ var (
 	flagFullAddress *bool
 	flagJSON        *bool
 	flagDERPMapURL  *string
+	flagAutoRegion  *bool
 )
 
 // The genkey subcommand's flags, likewise set by newRootCommand.
@@ -91,6 +92,7 @@ func newRootCommand() *ff.Command {
 	flagVerbose = rootFS.BoolLong("verbose", "be verbose")
 	flagJSON = rootFS.BoolLong("json", "in server mode, write {\"listenAddr\": ...} JSON to stdout")
 	flagDERPMapURL = rootFS.StringLong("derpmap-url", cmp.Or(os.Getenv("TAILCAT_DERPMAP_URL"), tailcat.DefaultDERPMapURL), "URL of the JSON DERP map used to resolve or auto-select a DERP region; its default can also be set with the TAILCAT_DERPMAP_URL environment variable")
+	flagAutoRegion = rootFS.BoolLong("auto-region", "in client modes, if the server doesn't answer in the DERP region its address says, search the DERP map for the region it moved to and print its current address. Useful for a server whose key was made with 'genkey --region=auto', which re-picks a region at every startup")
 
 	serveFS := ff.NewFlagSet("serve").SetParent(rootFS)
 	flagAllow = serveFS.StringLong("allow", "", "comma-separated list of public keys to allow access to the server, or 'none' to allow no clients. If empty, all clients are allowed.")
@@ -102,7 +104,7 @@ func newRootCommand() *ff.Command {
 
 	pingFS := ff.NewFlagSet("ping").SetParent(rootFS)
 	pingUntilDirect := pingFS.BoolLong("until-direct", "keep pinging until a pong arrives over a direct (non-DERP) path; exit non-zero if that doesn't happen before --timeout")
-	pingTimeout := pingFS.DurationLong("timeout", 10*time.Second, "give up after this long")
+	pingTimeout := pingFS.DurationLong("timeout", 10*time.Second, "give up after this long (default 60s with --auto-region, which has a whole DERP map to search)")
 
 	socksFS := ff.NewFlagSet("socks").SetParent(rootFS)
 	socksListen := socksFS.StringLong("listen", "127.0.0.1:0", "SOCKS5 proxy listen [address]:port; a bare port means localhost, a bare address means an OS-assigned port")
@@ -153,7 +155,11 @@ func newRootCommand() *ff.Command {
 				LongHelp:  pingLongHelp,
 				Flags:     pingFS,
 				Exec: func(ctx context.Context, args []string) error {
-					return clientPingMode(getLogf(), *pingUntilDirect, *pingTimeout, args)
+					timeout := *pingTimeout
+					if f, ok := pingFS.GetFlag("timeout"); *flagAutoRegion && ok && !f.IsSet() {
+						timeout = autoRegionTimeout
+					}
+					return clientPingMode(getLogf(), *pingUntilDirect, timeout, args)
 				},
 			},
 			{
@@ -319,6 +325,7 @@ relay or a direct path. --until-direct keeps pinging (bounded by
 
 	tailcat ping <tc-addr>
 	tailcat ping --until-direct <tc-addr>
+	tailcat ping --auto-region <tc-addr>
 
 Client mode, ssh:
 
@@ -743,8 +750,13 @@ func clientKey() key.NodePrivate {
 	return conf.Private
 }
 
+// autoRegionTimeout is the deadline the client modes give an operation
+// when --auto-region is set, in place of a shorter default: a search can
+// need a DERP map fetch and a probe of every region in it.
+const autoRegionTimeout = 60 * time.Second
+
 // newClient returns a [tailcat.Client] configured with the global
-// --derpmap-url flag and the disk DERP map cache.
+// --derpmap-url and --auto-region flags and the disk DERP map cache.
 func newClient(logf logger.Logf, addr tailcat.Addr, priv key.NodePrivate) *tailcat.Client {
 	return &tailcat.Client{
 		Server:       addr,
@@ -752,6 +764,13 @@ func newClient(logf logger.Logf, addr tailcat.Addr, priv key.NodePrivate) *tailc
 		Logf:         logf,
 		DERPMapURL:   *flagDERPMapURL,
 		DERPMapCache: derpMapCache{},
+		AutoRegion:   *flagAutoRegion,
+		// Stderr, not stdout: in client mode stdout is the connection
+		// itself, which ssh and scp use as a ProxyCommand.
+		OnRegionDiscovered: func(cur tailcat.Addr, r *tailcfg.DERPRegion) {
+			fmt.Fprintf(os.Stderr, "# server moved to DERP region %v (%v); its current address is:\n#   %v\n",
+				r.RegionID, cmp.Or(r.RegionCode, r.RegionName), cur)
+		},
 	}
 }
 

--- a/region.go
+++ b/region.go
@@ -6,16 +6,20 @@ package tailcat
 import (
 	"cmp"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"tailscale.com/derp"
 	"tailscale.com/derp/derphttp"
+	"tailscale.com/disco"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/netns"
 	"tailscale.com/tailcfg"
@@ -31,32 +35,112 @@ const (
 	// region again alongside the others.
 	probeConfirmTimeout = 3 * time.Second
 
-	// probeSearchTimeout bounds the widened search.
-	probeSearchTimeout = 15 * time.Second
-
-	// probeSettle is how long a search waits, after the first region
-	// answers, for one of the regions the address already names to
-	// answer too. A server reachable in several regions would otherwise
-	// have its address rewritten to whichever relay happened to reply
-	// first.
-	probeSettle = 250 * time.Millisecond
+	// probeSettle bounds how long a search waits, after some other
+	// region answers, for a region the address already names to answer
+	// too. A server reachable in several regions would otherwise have
+	// its address rewritten to whichever relay happened to reply first.
+	//
+	// It is only a bound: the wait ends as soon as every named region
+	// has finished probing, which is the answer it is really waiting
+	// for. The bound is generous because the alternative to waiting is
+	// rewriting an address that is published and still correct, and
+	// because a server's first meow after connecting is often dropped,
+	// so "slower to answer" and "not there" look alike for a moment.
+	probeSettle = 2 * time.Second
 
 	// probeMeowInterval is how often a probe re-sends its meow. It is
 	// shorter than meowRetryInterval because a probe has only
-	// probeConfirmTimeout to get an answer, and the first meow after
+	// probeSlotTimeout to get an answer, and the first meow after
 	// connecting is often dropped while the server's own DERP connection
 	// is still coming up.
 	probeMeowInterval = 250 * time.Millisecond
 
-	// probeStagger spaces out the connections a widened search opens, so
-	// a large DERP map doesn't produce one burst of TLS handshakes.
+	// probeStagger spaces out the connections a search opens, so a large
+	// DERP map doesn't produce one burst of TLS handshakes.
 	probeStagger = 100 * time.Millisecond
 
-	// maxProbeRegions caps how many regions one search probes. Today's
-	// tailcat DERP map has four; the cap is here so that a much larger
-	// map can't turn one stale address into a storm.
-	maxProbeRegions = 8
+	// maxProbeConcurrency caps how many regions a search probes at once.
+	// Coverage is deliberately not capped: every region in the DERP map
+	// is probed eventually, so a server that moved anywhere in a map of
+	// any size is still found. What is bounded is how much of the search
+	// is in flight, so a stale address costs a fixed number of concurrent
+	// TLS handshakes rather than one per region.
+	maxProbeConcurrency = 8
+
+	// probeSlotTimeout is how long one region may hold its slot in the
+	// pool while other regions are still waiting for one. Without it the
+	// first maxProbeConcurrency regions would hold their slots for the
+	// whole search and the rest would never be probed at all.
+	//
+	// A probe whose slot nothing else is waiting for keeps running to the
+	// end of the search instead, so a map small enough to probe in one
+	// wave behaves exactly as it did before the pool existed.
+	probeSlotTimeout = 3 * time.Second
+
+	// probeNotHereGrace is how long a probe keeps meowing after the relay
+	// first reports that it holds no connection for the server.
+	//
+	// A relay answers for the instant it is asked, and it answers fast:
+	// the reply lands within a millisecond or two of connecting, well
+	// before a server that is really there has answered a meow. A server
+	// that has just restarted — the usual reason a search is running at
+	// all — is briefly absent from the region it is really in, and the
+	// first meow after connecting is often dropped while its own DERP
+	// connection comes up, so a live server can take several hundred
+	// milliseconds to answer. The grace has to cover that, and it still
+	// halves what an empty region costs compared with waiting out
+	// probeSlotTimeout.
+	//
+	// A region written off this way is not written off for good: a
+	// search that reaches the end of the map without an answer looks
+	// again, and that second look ignores the relay entirely. See
+	// DiscoverRegion.
+	probeNotHereGrace = 1500 * time.Millisecond
+
+	// probeSearchTimeoutMin and probeSearchTimeoutMax bound the search
+	// budget that searchTimeout derives from the size of the map.
+	probeSearchTimeoutMin = 15 * time.Second
+	probeSearchTimeoutMax = 45 * time.Second
 )
+
+var (
+	// errNoResponse is a probe that ran out of time with nothing heard.
+	errNoResponse = errors.New("no response")
+
+	// errNotHere is a probe the relay itself cut short: it holds no
+	// connection for the server's node key. See discoProbePacket.
+	errNotHere = errors.New("relay has no record of the server")
+
+	// errYielded is a probe that gave up its slot in the pool to a
+	// region that had not been probed yet. It says nothing about
+	// whether the server is there.
+	errYielded = errors.New("no response yet; yielded to regions not probed yet")
+)
+
+// searchTimeout returns how long a search over n regions gets: enough
+// for the pool to reach every one of them, since a map larger than
+// maxProbeConcurrency is worked through a wave at a time.
+func searchTimeout(n int) time.Duration {
+	waves := (n + maxProbeConcurrency - 1) / maxProbeConcurrency
+	d := time.Duration(waves)*probeSlotTimeout + time.Duration(min(n, maxProbeConcurrency))*probeStagger
+	return min(max(d, probeSearchTimeoutMin), probeSearchTimeoutMax)
+}
+
+// RegionCache remembers the DERP region a search last found a server in,
+// so a client that has already paid for one search doesn't repeat it on
+// every later connection. A cached region is probed alongside the one
+// the address names rather than in place of it, so a wrong entry costs
+// one extra probe and is corrected by the search that follows; entries
+// need no expiry for that reason.
+//
+// Implementations must be safe for concurrent use.
+type RegionCache interface {
+	// GetRegion returns the region a search last found serverPub in.
+	GetRegion(serverPub key.NodePublic) (regionID tailcfg.DERPRegionID, ok bool)
+
+	// PutRegion records that serverPub answered in regionID.
+	PutRegion(serverPub key.NodePublic, regionID tailcfg.DERPRegionID) error
+}
 
 // DiscoverRegion returns an address equivalent to addr but naming the
 // DERP region where the server is reachable now, for a server that has
@@ -67,6 +151,9 @@ const (
 // address and doesn't change, so DiscoverRegion keeps it and asks each
 // candidate region whether the server is there, using the same meow
 // handshake a real connection makes.
+//
+// Every region in the DERP map is searched, however many that is; only
+// the number probed at once is bounded (see maxProbeConcurrency).
 //
 // If the server answers in the region addr already names, addr is
 // returned unchanged.
@@ -82,6 +169,8 @@ const (
 //     fetching one over the network.
 //   - [DERPMapCache]: cache fetched DERP maps (defaults to a
 //     process-wide in-memory cache).
+//   - [RegionCache]: remember where the server was found, and look
+//     there first next time.
 //   - [logger.Logf]: where to log the progress of the search.
 func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, opts ...any) (Addr, error) {
 	ci, err := ParseAddr(addr)
@@ -95,6 +184,7 @@ func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, o
 	fetchURL := DefaultDERPMapURL
 	var dm *tailcfg.DERPMap
 	var cache DERPMapCache
+	var regions RegionCache
 	logf := logger.Discard
 	for _, opt := range opts {
 		switch v := opt.(type) {
@@ -104,6 +194,8 @@ func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, o
 			dm = v
 		case DERPMapCache:
 			cache = v
+		case RegionCache:
+			regions = v
 		case logger.Logf:
 			logf = v
 		default:
@@ -132,7 +224,30 @@ func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, o
 		// will: onMeow keeps the disco key from the first meow it sees and
 		// ignores later ones, so a probe presenting a different key would
 		// leave the server with an entry the real client can't correct.
-		pkt: EncodeMeowPing(clientKey.Public(), DiscoPublicForNode(clientKey).DiscoPublic),
+		pkt:      EncodeMeowPing(clientKey.Public(), DiscoPublicForNode(clientKey).DiscoPublic),
+		discoPkt: discoProbePacket(clientKey, ci.ServerDiscoPublic.DiscoPublic),
+	}
+
+	// answer turns a winning candidate into the address to use. A region
+	// the address already names leaves it alone; anything else rewrites
+	// the region and, so the next connection can skip the search,
+	// records it.
+	answer := func(c probeCandidate) (Addr, error) {
+		if c.named {
+			return addr, nil
+		}
+		if regions != nil {
+			if err := regions.PutRegion(ci.ServerPublic.NodePublic, c.reg.RegionID); err != nil {
+				logf("auto-region: remembering region %v: %v", c.reg.RegionID, err)
+			}
+		}
+		// Multi-region servers are a possibility (tailcat#7), so probe
+		// reports every region that answered; today the client connects
+		// to one, and the short RegionID form is the only one whose
+		// region ID survives a round trip through an [Addr].
+		ci.Region = nil
+		ci.RegionID = c.reg.RegionID
+		return ci.Addr(), nil
 	}
 
 	named, embedded := ci.Region, len(ci.Region) > 0
@@ -149,11 +264,34 @@ func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, o
 	for _, r := range named {
 		namedCands = append(namedCands, probeCandidate{r, true})
 	}
-	if len(namedCands) > 0 {
-		if got := p.probe(ctx, namedCands, probeConfirmTimeout); len(got) > 0 {
-			return addr, nil
+
+	// Where a previous search found the server is probed alongside the
+	// regions the address names, not instead of them: it goes in
+	// unnamed, so if the address's own region answers too, probe's
+	// preference for a named region leaves the address alone.
+	confirm := namedCands
+	if regions != nil {
+		if id, ok := regions.GetRegion(ci.ServerPublic.NodePublic); ok {
+			if m, err := getMap(); err == nil {
+				if r := m.Regions[id]; r != nil && !slices.ContainsFunc(confirm, func(c probeCandidate) bool {
+					return c.reg.RegionID == id
+				}) {
+					confirm = append(slices.Clip(confirm), probeCandidate{r, false})
+				}
+			}
 		}
-		logf("auto-region: no response in %v; searching the rest of the DERP map", regionList(namedCands))
+	}
+	if len(confirm) > 0 {
+		// Taking the relay's word here can only cost time, never the
+		// right answer: the search that follows probes these regions
+		// first and returns the address unchanged if one of them
+		// answers, so a server still coming up in the region its
+		// address names is found a moment later rather than reported
+		// as moved.
+		if got := p.probe(ctx, confirm, probeConfirmTimeout, true); len(got) > 0 {
+			return answer(got[0])
+		}
+		logf("auto-region: no response in %v; searching the rest of the DERP map", regionList(confirm))
 	}
 
 	m, err := getMap()
@@ -164,25 +302,61 @@ func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, o
 	if len(cands) == 0 {
 		return "", fmt.Errorf("no DERP regions to search in %v", fetchURL)
 	}
-	got := p.probe(ctx, cands, probeSearchTimeout)
+	// Two looks, sharing one budget. The first sweeps the whole map fast,
+	// taking a relay's word that it has no connection for the server so
+	// that a slot frees up for the next region; that is what lets the
+	// search cover a map of any size. But a relay answers only for the
+	// instant it is asked, and the usual reason a search is running at
+	// all is that the server has just restarted — so if the sweep comes
+	// back empty, the second look ignores the relay and waits the rest of
+	// the budget out for the server to appear.
+	deadline := time.Now().Add(searchTimeout(len(cands)))
+	got := p.probe(ctx, cands, time.Until(deadline), true)
+	if len(got) == 0 && time.Now().Before(deadline) {
+		logf("auto-region: no region has the server yet; waiting in %v", regionList(cands))
+		got = p.probe(ctx, cands, time.Until(deadline), false)
+	}
 	if len(got) == 0 {
 		// A server ignores meows from a client that isn't on its --allow
 		// list in exactly the way an absent server does, so name both.
-		return "", fmt.Errorf("no response from the server in DERP regions %v; it may be on a relay not listed in %v, or this client's key may not be on its --allow list",
-			regionList(cands), fetchURL)
+		return "", fmt.Errorf("no response from the server in any of the %d DERP regions in %v (%v); it may be on a relay not listed there, or this client's key may not be on its --allow list",
+			len(cands), fetchURL, regionList(cands))
 	}
 	// The search re-probes the regions the address names, so a confirm
 	// that merely ran slow lands here rather than costing the connection.
-	if got[0].named {
-		return addr, nil
-	}
-	// Multi-region servers are a possibility (tailcat#7), so probe reports
-	// every region that answered; today the client connects to one, and
-	// the short RegionID form is the only one whose region ID survives a
-	// round trip through an [Addr].
-	ci.Region = nil
-	ci.RegionID = got[0].reg.RegionID
-	return ci.Addr(), nil
+	return answer(got[0])
+}
+
+// discoProbePacket returns a disco-framed packet addressed to the
+// server's disco key, which a probe sends alongside its meow.
+//
+// Nothing answers it. A live server's magicsock drops disco from a peer
+// it doesn't know, which is what keeps this from being a way around the
+// server's --allow list — only a meowed counts as the server answering.
+// Its job is to look like disco to the *relay*: derpserver replies "peer
+// gone, not here" for a disco packet addressed to a node key it holds no
+// connection for, and stays silent for anything else, meows included
+// (requestPeerGoneWriteLimited). That turns a region the server has left
+// into an immediate answer instead of a timeout, which is what lets a
+// search cover a large map in one search budget.
+func discoProbePacket(clientKey key.NodePrivate, serverDisco key.DiscoPublic) []byte {
+	var txid [12]byte
+	rand.Read(txid[:])
+	payload := (&disco.Ping{TxID: txid, NodeKey: clientKey.Public()}).AppendMarshal(nil)
+	priv := discoPrivateForNode(clientKey)
+	pkt := make([]byte, 0, 128)
+	pkt = append(pkt, disco.Magic...)
+	pkt = priv.Public().AppendTo(pkt)
+	return append(pkt, priv.Shared(serverDisco).Seal(payload)...)
+}
+
+// probeResult is one finished probe: the region, and whether the server
+// answered there. Failures are reported too, so the collector can tell
+// a region the address names that is still being probed from one that
+// has finished and found nothing.
+type probeResult struct {
+	cand probeCandidate
+	ok   bool
 }
 
 // probeCandidate is a region to probe, and whether the address being
@@ -194,12 +368,21 @@ type probeCandidate struct {
 
 // searchCandidates returns the regions to probe for a server that did
 // not answer in the regions its address named: those regions first, then
-// the rest of dm by ascending ID.
+// every other region in dm, nearest first.
 //
 // The named regions are probed again rather than skipped. A confirm stage
 // that timed out only because the relay was slow to come up would
 // otherwise report a server that never moved as moved, or fail outright
 // when nothing else answers.
+//
+// The rest are ordered by great-circle distance from the named region,
+// because a server that re-picks its region by latency and lands
+// somewhere new has almost always landed near where it was: the region
+// it left was its nearest, so its replacement is usually the next
+// nearest. Probing outward finds it in the first wave far more often
+// than ascending region ID does, which matters once the map is larger
+// than one wave. Regions the map gives no coordinates for keep their ID
+// order, after the ones it does.
 //
 // embedded says whether named came from the address rather than from dm.
 // An embedded address's regions carry no usable ID — [ConnInfo.Addr]
@@ -229,11 +412,54 @@ func searchCandidates(dm *tailcfg.DERPMap, named []probeCandidate, embedded bool
 		}) {
 			continue
 		}
-		if cands = append(cands, probeCandidate{r, false}); len(cands) == maxProbeRegions {
-			break
-		}
+		cands = append(cands, probeCandidate{r, false})
+	}
+	// An embedded address's regions carry no coordinates (wireRegionOf
+	// drops them), so there is nothing to measure from and the ID order
+	// stands.
+	if lat, lon, ok := originCoords(named); ok {
+		rest := cands[len(named):]
+		slices.SortStableFunc(rest, func(a, b probeCandidate) int {
+			da, aok := distanceKm(lat, lon, a.reg)
+			db, bok := distanceKm(lat, lon, b.reg)
+			switch {
+			case aok && bok:
+				return cmp.Compare(da, db)
+			case aok:
+				return -1
+			case bok:
+				return 1
+			}
+			return 0
+		})
 	}
 	return cands
+}
+
+// originCoords returns the coordinates to order a search around: those
+// of the first named region the map gives any for.
+func originCoords(named []probeCandidate) (lat, lon float64, ok bool) {
+	for _, c := range named {
+		if c.reg.Latitude != 0 || c.reg.Longitude != 0 {
+			return c.reg.Latitude, c.reg.Longitude, true
+		}
+	}
+	return 0, 0, false
+}
+
+// distanceKm returns the great-circle distance from (lat, lon) to reg,
+// and whether reg has coordinates at all. A region with neither is
+// reported as unknown rather than as a point off the coast of Africa.
+func distanceKm(lat, lon float64, reg *tailcfg.DERPRegion) (float64, bool) {
+	if reg.Latitude == 0 && reg.Longitude == 0 {
+		return 0, false
+	}
+	const earthRadiusKm = 6371
+	rad := func(d float64) float64 { return d * math.Pi / 180 }
+	dLat, dLon := rad(reg.Latitude-lat), rad(reg.Longitude-lon)
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(rad(lat))*math.Cos(rad(reg.Latitude))*math.Sin(dLon/2)*math.Sin(dLon/2)
+	return 2 * earthRadiusKm * math.Asin(min(1, math.Sqrt(a))), true
 }
 
 // regionProber sends meow pings to DERP regions to find which of them a
@@ -244,26 +470,54 @@ type regionProber struct {
 	priv      key.NodePrivate
 	serverPub key.NodePublic
 	pkt       []byte
+	discoPkt  []byte
 }
 
-// probe meows every region in cands at once and returns those that
-// answered, the preferred one first, giving up after timeout.
+// probe meows the regions in cands, maxProbeConcurrency of them at a
+// time, and returns those that answered, the preferred one first, giving
+// up after timeout.
 //
 // A server may be registered in more than one region at a time
-// (tailcat#7), and a region the address already names is probed alongside
-// the rest, so several may answer. probe returns on the first answer,
-// except that it waits probeSettle longer for a region the address names,
-// whose answer means the address is still good and should not be
+// (tailcat#7), and a region the address already names is probed
+// alongside the rest, so several may answer. probe returns on the first
+// answer from a region the address names, and otherwise holds an answer
+// until every named region has finished probing (bounded by
+// probeSettle), so that an address whose own region still works is not
 // rewritten. Callers must not read a single winner as proof the others
 // are dead.
-func (p *regionProber) probe(ctx context.Context, cands []probeCandidate, timeout time.Duration) []probeCandidate {
+//
+// trustNotHere says whether a relay reporting no connection for the
+// server ends that region's probe. It makes a sweep of a large map cheap,
+// at the cost of writing off a server that has not finished connecting;
+// see probeNotHereGrace and DiscoverRegion.
+func (p *regionProber) probe(ctx context.Context, cands []probeCandidate, timeout time.Duration, trustNotHere bool) []probeCandidate {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	t0 := time.Now()
-	answers := make(chan probeCandidate, len(cands))
+	results := make(chan probeResult, len(cands))
+	queue := make(chan probeCandidate)
+
+	// waiting counts the regions no worker has taken up yet. A probe
+	// yields its slot after probeSlotTimeout only while this is non-zero:
+	// once every region has been handed out there is no one to make room
+	// for, so the probes still running get the rest of the search.
+	var waiting atomic.Int64
+	waiting.Store(int64(len(cands)))
+	go func() {
+		defer close(queue)
+		for _, c := range cands {
+			waiting.Add(-1)
+			select {
+			case queue <- c:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	var wg sync.WaitGroup
-	for i, c := range cands {
+	for i := range min(len(cands), maxProbeConcurrency) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -274,37 +528,61 @@ func (p *regionProber) probe(ctx context.Context, cands []probeCandidate, timeou
 					return
 				}
 			}
-			if err := p.probeOne(ctx, c.reg); err != nil {
-				p.logf("auto-region: region %v (%v): %v", c.reg.RegionID, regionCode(c.reg), err)
-				return
+			for c := range queue {
+				err := p.probeSlot(ctx, c.reg, func() bool { return waiting.Load() > 0 }, trustNotHere)
+				if err != nil {
+					p.logf("auto-region: region %v (%v): %v", c.reg.RegionID, regionCode(c.reg), err)
+				} else {
+					p.logf("auto-region: region %v (%v): server responded in %v", c.reg.RegionID, regionCode(c.reg),
+						time.Since(t0).Round(time.Millisecond))
+				}
+				results <- probeResult{c, err == nil}
 			}
-			p.logf("auto-region: region %v (%v): server responded in %v", c.reg.RegionID, regionCode(c.reg),
-				time.Since(t0).Round(time.Millisecond))
-			answers <- c
 		}()
 	}
 	go func() {
 		wg.Wait()
-		close(answers)
+		close(results)
 	}()
 
+	// namedLeft counts the regions the address names that have not
+	// finished probing. An answer from anywhere else is held until that
+	// reaches zero — an address whose own region still works must not be
+	// rewritten, and only the named probe finishing settles that — or
+	// until probeSettle runs out, whichever comes first.
+	var namedLeft int
+	for _, c := range cands {
+		if c.named {
+			namedLeft++
+		}
+	}
+
 	var got []probeCandidate
-	settle := make(<-chan time.Time) // nil until the first answer
-	anyNamed := slices.ContainsFunc(cands, func(c probeCandidate) bool { return c.named })
+	var settle <-chan time.Time // nil until something answers
 collect:
 	for {
 		select {
-		case c, ok := <-answers:
+		case r, ok := <-results:
 			if !ok {
 				break collect
 			}
-			got = append(got, c)
-			if c.named || !anyNamed {
+			if r.ok {
+				got = append(got, r.cand)
+				if r.cand.named {
+					break collect
+				}
+			} else if r.cand.named {
+				namedLeft--
+			}
+			if len(got) == 0 {
+				continue
+			}
+			if namedLeft == 0 {
 				break collect
 			}
-			// Give a region the address names a moment to answer
-			// too, rather than rewriting an address that still works.
-			settle = time.After(probeSettle)
+			if settle == nil {
+				settle = time.After(probeSettle)
+			}
 		case <-settle:
 			break collect
 		}
@@ -328,8 +606,43 @@ collect:
 	return got
 }
 
-// probeOne meows reg until the server acks or ctx expires.
-func (p *regionProber) probeOne(ctx context.Context, reg *tailcfg.DERPRegion) error {
+// probeSlot probes reg, giving up its slot in the pool after
+// probeSlotTimeout if waiting reports that other regions still need one.
+func (p *regionProber) probeSlot(ctx context.Context, reg *tailcfg.DERPRegion, waiting func() bool, trustNotHere bool) error {
+	pctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var yielded atomic.Bool
+	go func() {
+		t := time.NewTicker(probeSlotTimeout)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				if waiting() {
+					yielded.Store(true)
+					cancel()
+					return
+				}
+			case <-pctx.Done():
+				return
+			}
+		}
+	}()
+
+	err := p.probeOne(pctx, reg, trustNotHere)
+	if err != nil && yielded.Load() && ctx.Err() == nil {
+		return errYielded
+	}
+	return err
+}
+
+// probeOne meows reg until the server acks, the relay convinces us it
+// has no connection for the server, or ctx expires.
+func (p *regionProber) probeOne(ctx context.Context, reg *tailcfg.DERPRegion, trustNotHere bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	dc := derphttp.NewRegionClient(p.priv, p.logf, p.netMon, func() *tailcfg.DERPRegion { return reg })
 	dc.AppName = "tailcat-probe"
 	dc.BaseContext = func() context.Context { return ctx }
@@ -346,12 +659,41 @@ func (p *regionProber) probeOne(ctx context.Context, reg *tailcfg.DERPRegion) er
 		case <-done:
 		}
 	}()
+
+	// notHere is closed when the relay first reports no connection for
+	// the server, and absent records that the grace after that ran out
+	// with the server still silent. Only then is the region written off:
+	// see probeNotHereGrace.
+	notHere := make(chan struct{})
+	var notHereOnce sync.Once
+	var absent atomic.Bool
+	go func() {
+		select {
+		case <-notHere:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case <-time.After(probeNotHereGrace):
+			absent.Store(true)
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	go func() {
 		t := time.NewTicker(probeMeowInterval)
 		defer t.Stop()
 		for {
 			if err := dc.Send(p.serverPub, p.pkt); err != nil && ctx.Err() == nil {
 				p.logf("auto-region: region %v: sending meow: %v", reg.RegionID, err)
+			}
+			// Only the server answers a meow; only a disco packet gets
+			// the relay to say the server isn't there at all. Send both,
+			// so an empty region costs a grace period rather than the
+			// whole slot. See discoProbePacket.
+			if err := dc.Send(p.serverPub, p.discoPkt); err != nil && ctx.Err() == nil {
+				p.logf("auto-region: region %v: sending disco probe: %v", reg.RegionID, err)
 			}
 			select {
 			case <-t.C:
@@ -367,20 +709,30 @@ func (p *regionProber) probeOne(ctx context.Context, reg *tailcfg.DERPRegion) er
 		m, err := dc.Recv()
 		if err != nil {
 			if ctx.Err() != nil {
-				return errors.New("no response")
+				if absent.Load() {
+					return errNotHere
+				}
+				return errNoResponse
 			}
 			// derphttp reconnects on the next call; don't spin on a
 			// relay that keeps dropping us.
 			select {
 			case <-time.After(250 * time.Millisecond):
 			case <-ctx.Done():
-				return errors.New("no response")
+				return errNoResponse
 			}
 			continue
 		}
-		// Data aliases Recv's buffer, so don't hold on to it.
-		if pkt, ok := m.(derp.ReceivedPacket); ok && pkt.Source == p.serverPub && IsMeowedPacket(pkt.Data) {
-			return nil
+		switch m := m.(type) {
+		case derp.ReceivedPacket:
+			// Data aliases Recv's buffer, so don't hold on to it.
+			if m.Source == p.serverPub && IsMeowedPacket(m.Data) {
+				return nil
+			}
+		case derp.PeerGoneMessage:
+			if trustNotHere && m.Peer == p.serverPub && m.Reason == derp.PeerGoneReasonNotHere {
+				notHereOnce.Do(func() { close(notHere) })
+			}
 		}
 	}
 }
@@ -389,10 +741,16 @@ func regionCode(r *tailcfg.DERPRegion) string {
 	return cmp.Or(r.RegionCode, r.RegionName, fmt.Sprint(r.RegionID))
 }
 
-// regionList formats regions for an error or log message.
+// regionList formats regions for an error or log message, abbreviating a
+// list too long to print in full.
 func regionList(cands []probeCandidate) string {
+	const maxShown = 8
 	var sb strings.Builder
 	for i, c := range cands {
+		if i == maxShown {
+			fmt.Fprintf(&sb, ", and %d more", len(cands)-maxShown)
+			break
+		}
 		if i > 0 {
 			sb.WriteString(", ")
 		}

--- a/region.go
+++ b/region.go
@@ -1,0 +1,402 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tailcat
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"tailscale.com/derp"
+	"tailscale.com/derp/derphttp"
+	"tailscale.com/net/netmon"
+	"tailscale.com/net/netns"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
+	"tailscale.com/util/set"
+)
+
+const (
+	// probeConfirmTimeout is how long the region an address names gets
+	// to answer on its own before the search widens to the rest of the
+	// map. A miss here is not fatal: the widened search probes that
+	// region again alongside the others.
+	probeConfirmTimeout = 3 * time.Second
+
+	// probeSearchTimeout bounds the widened search.
+	probeSearchTimeout = 15 * time.Second
+
+	// probeSettle is how long a search waits, after the first region
+	// answers, for one of the regions the address already names to
+	// answer too. A server reachable in several regions would otherwise
+	// have its address rewritten to whichever relay happened to reply
+	// first.
+	probeSettle = 250 * time.Millisecond
+
+	// probeMeowInterval is how often a probe re-sends its meow. It is
+	// shorter than meowRetryInterval because a probe has only
+	// probeConfirmTimeout to get an answer, and the first meow after
+	// connecting is often dropped while the server's own DERP connection
+	// is still coming up.
+	probeMeowInterval = 250 * time.Millisecond
+
+	// probeStagger spaces out the connections a widened search opens, so
+	// a large DERP map doesn't produce one burst of TLS handshakes.
+	probeStagger = 100 * time.Millisecond
+
+	// maxProbeRegions caps how many regions one search probes. Today's
+	// tailcat DERP map has four; the cap is here so that a much larger
+	// map can't turn one stale address into a storm.
+	maxProbeRegions = 8
+)
+
+// DiscoverRegion returns an address equivalent to addr but naming the
+// DERP region where the server is reachable now, for a server that has
+// moved since addr was published. A server started with "genkey
+// --region=auto" re-picks its region by latency at every startup, so an
+// address handed out earlier can name a region it has since left; the
+// client then just times out. The server's identity travels in the
+// address and doesn't change, so DiscoverRegion keeps it and asks each
+// candidate region whether the server is there, using the same meow
+// handshake a real connection makes.
+//
+// If the server answers in the region addr already names, addr is
+// returned unchanged.
+//
+// clientKey must be the node key the caller will connect with: a server
+// started with --allow ignores meows from any other key, so discovery with
+// a throwaway key would find nothing.
+//
+// The opts may contain any of the following types:
+//   - [DERPMapURL]: fetch the DERP map from an alternate URL instead
+//     of [DefaultDERPMapURL].
+//   - [*tailcfg.DERPMap]: search the provided DERP map instead of
+//     fetching one over the network.
+//   - [DERPMapCache]: cache fetched DERP maps (defaults to a
+//     process-wide in-memory cache).
+//   - [logger.Logf]: where to log the progress of the search.
+func DiscoverRegion(ctx context.Context, addr Addr, clientKey key.NodePrivate, opts ...any) (Addr, error) {
+	ci, err := ParseAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	if ci.ServerDiscoPublic.IsZero() {
+		return "", errors.New("legacy server address lacks a separate disco key; generate a new address with an updated tailcat server")
+	}
+
+	fetchURL := DefaultDERPMapURL
+	var dm *tailcfg.DERPMap
+	var cache DERPMapCache
+	logf := logger.Discard
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case DERPMapURL:
+			fetchURL = string(v)
+		case *tailcfg.DERPMap:
+			dm = v
+		case DERPMapCache:
+			cache = v
+		case logger.Logf:
+			logf = v
+		default:
+			return "", fmt.Errorf("unknown DiscoverRegion option type %T", opt)
+		}
+	}
+	getMap := func() (*tailcfg.DERPMap, error) {
+		if dm == nil {
+			dm, err = fetchDERPMap(ctx, fetchURL, "client", cache)
+			if err != nil {
+				return nil, fmt.Errorf("fetching DERP map to search for the server: %w", err)
+			}
+		}
+		return dm, nil
+	}
+
+	// derphttp dials through netns, which createEngine disables for the
+	// real connection; probe the same way it will.
+	netns.SetEnabled(false)
+	p := &regionProber{
+		netMon:    netmon.NewStatic(),
+		logf:      logf,
+		priv:      clientKey,
+		serverPub: ci.ServerPublic.NodePublic,
+		// The probe registers with the server exactly as the real client
+		// will: onMeow keeps the disco key from the first meow it sees and
+		// ignores later ones, so a probe presenting a different key would
+		// leave the server with an entry the real client can't correct.
+		pkt: EncodeMeowPing(clientKey.Public(), DiscoPublicForNode(clientKey).DiscoPublic),
+	}
+
+	named, embedded := ci.Region, len(ci.Region) > 0
+	if !embedded && ci.RegionID > 0 {
+		m, err := getMap()
+		if err != nil {
+			return "", err
+		}
+		if r, ok := m.Regions[ci.RegionID]; ok {
+			named = []*tailcfg.DERPRegion{r}
+		}
+	}
+	var namedCands []probeCandidate
+	for _, r := range named {
+		namedCands = append(namedCands, probeCandidate{r, true})
+	}
+	if len(namedCands) > 0 {
+		if got := p.probe(ctx, namedCands, probeConfirmTimeout); len(got) > 0 {
+			return addr, nil
+		}
+		logf("auto-region: no response in %v; searching the rest of the DERP map", regionList(namedCands))
+	}
+
+	m, err := getMap()
+	if err != nil {
+		return "", err
+	}
+	cands := searchCandidates(m, namedCands, embedded)
+	if len(cands) == 0 {
+		return "", fmt.Errorf("no DERP regions to search in %v", fetchURL)
+	}
+	got := p.probe(ctx, cands, probeSearchTimeout)
+	if len(got) == 0 {
+		// A server ignores meows from a client that isn't on its --allow
+		// list in exactly the way an absent server does, so name both.
+		return "", fmt.Errorf("no response from the server in DERP regions %v; it may be on a relay not listed in %v, or this client's key may not be on its --allow list",
+			regionList(cands), fetchURL)
+	}
+	// The search re-probes the regions the address names, so a confirm
+	// that merely ran slow lands here rather than costing the connection.
+	if got[0].named {
+		return addr, nil
+	}
+	// Multi-region servers are a possibility (tailcat#7), so probe reports
+	// every region that answered; today the client connects to one, and
+	// the short RegionID form is the only one whose region ID survives a
+	// round trip through an [Addr].
+	ci.Region = nil
+	ci.RegionID = got[0].reg.RegionID
+	return ci.Addr(), nil
+}
+
+// probeCandidate is a region to probe, and whether the address being
+// resolved already names it.
+type probeCandidate struct {
+	reg   *tailcfg.DERPRegion
+	named bool
+}
+
+// searchCandidates returns the regions to probe for a server that did
+// not answer in the regions its address named: those regions first, then
+// the rest of dm by ascending ID.
+//
+// The named regions are probed again rather than skipped. A confirm stage
+// that timed out only because the relay was slow to come up would
+// otherwise report a server that never moved as moved, or fail outright
+// when nothing else answers.
+//
+// embedded says whether named came from the address rather than from dm.
+// An embedded address's regions carry no usable ID — [ConnInfo.Addr]
+// strips it and [ParseAddr] synthesizes 1..N in its place — so a dm
+// region is recognized as one of them by relay hostname instead. A
+// mismatch either way only costs one duplicate probe.
+func searchCandidates(dm *tailcfg.DERPMap, named []probeCandidate, embedded bool) []probeCandidate {
+	seenID := set.Set[tailcfg.DERPRegionID]{}
+	seenHost := set.Set[string]{}
+	for _, c := range named {
+		if embedded {
+			for _, n := range c.reg.Nodes {
+				seenHost.Add(strings.ToLower(n.HostName))
+			}
+			continue
+		}
+		seenID.Add(c.reg.RegionID)
+	}
+	cands := slices.Clone(named)
+	for _, id := range slices.Sorted(maps.Keys(dm.Regions)) {
+		r := dm.Regions[id]
+		if r == nil || seenID.Contains(id) {
+			continue
+		}
+		if len(seenHost) > 0 && slices.ContainsFunc(r.Nodes, func(n *tailcfg.DERPNode) bool {
+			return seenHost.Contains(strings.ToLower(n.HostName))
+		}) {
+			continue
+		}
+		if cands = append(cands, probeCandidate{r, false}); len(cands) == maxProbeRegions {
+			break
+		}
+	}
+	return cands
+}
+
+// regionProber sends meow pings to DERP regions to find which of them a
+// server is connected to.
+type regionProber struct {
+	netMon    *netmon.Monitor
+	logf      logger.Logf
+	priv      key.NodePrivate
+	serverPub key.NodePublic
+	pkt       []byte
+}
+
+// probe meows every region in cands at once and returns those that
+// answered, the preferred one first, giving up after timeout.
+//
+// A server may be registered in more than one region at a time
+// (tailcat#7), and a region the address already names is probed alongside
+// the rest, so several may answer. probe returns on the first answer,
+// except that it waits probeSettle longer for a region the address names,
+// whose answer means the address is still good and should not be
+// rewritten. Callers must not read a single winner as proof the others
+// are dead.
+func (p *regionProber) probe(ctx context.Context, cands []probeCandidate, timeout time.Duration) []probeCandidate {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	t0 := time.Now()
+	answers := make(chan probeCandidate, len(cands))
+	var wg sync.WaitGroup
+	for i, c := range cands {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if i > 0 {
+				select {
+				case <-time.After(time.Duration(i) * probeStagger):
+				case <-ctx.Done():
+					return
+				}
+			}
+			if err := p.probeOne(ctx, c.reg); err != nil {
+				p.logf("auto-region: region %v (%v): %v", c.reg.RegionID, regionCode(c.reg), err)
+				return
+			}
+			p.logf("auto-region: region %v (%v): server responded in %v", c.reg.RegionID, regionCode(c.reg),
+				time.Since(t0).Round(time.Millisecond))
+			answers <- c
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(answers)
+	}()
+
+	var got []probeCandidate
+	settle := make(<-chan time.Time) // nil until the first answer
+	anyNamed := slices.ContainsFunc(cands, func(c probeCandidate) bool { return c.named })
+collect:
+	for {
+		select {
+		case c, ok := <-answers:
+			if !ok {
+				break collect
+			}
+			got = append(got, c)
+			if c.named || !anyNamed {
+				break collect
+			}
+			// Give a region the address names a moment to answer
+			// too, rather than rewriting an address that still works.
+			settle = time.After(probeSettle)
+		case <-settle:
+			break collect
+		}
+	}
+	// Named first, else fastest, which is the order they arrived in.
+	slices.SortStableFunc(got, func(a, b probeCandidate) int {
+		switch {
+		case a.named == b.named:
+			return 0
+		case a.named:
+			return -1
+		}
+		return 1
+	})
+	// Every probe must be shut down before the caller brings up its real
+	// connection: DERP hands a node key's traffic to whichever of its
+	// connections wrote last, so a probe left open to the winning region
+	// would fight the connection that replaces it.
+	cancel()
+	wg.Wait()
+	return got
+}
+
+// probeOne meows reg until the server acks or ctx expires.
+func (p *regionProber) probeOne(ctx context.Context, reg *tailcfg.DERPRegion) error {
+	dc := derphttp.NewRegionClient(p.priv, p.logf, p.netMon, func() *tailcfg.DERPRegion { return reg })
+	dc.AppName = "tailcat-probe"
+	dc.BaseContext = func() context.Context { return ctx }
+	defer dc.Close()
+
+	done := make(chan struct{})
+	defer close(done)
+	// Recv blocks in a socket read, so closing the client is the only way
+	// to interrupt it once ctx expires.
+	go func() {
+		select {
+		case <-ctx.Done():
+			dc.Close()
+		case <-done:
+		}
+	}()
+	go func() {
+		t := time.NewTicker(probeMeowInterval)
+		defer t.Stop()
+		for {
+			if err := dc.Send(p.serverPub, p.pkt); err != nil && ctx.Err() == nil {
+				p.logf("auto-region: region %v: sending meow: %v", reg.RegionID, err)
+			}
+			select {
+			case <-t.C:
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	for {
+		m, err := dc.Recv()
+		if err != nil {
+			if ctx.Err() != nil {
+				return errors.New("no response")
+			}
+			// derphttp reconnects on the next call; don't spin on a
+			// relay that keeps dropping us.
+			select {
+			case <-time.After(250 * time.Millisecond):
+			case <-ctx.Done():
+				return errors.New("no response")
+			}
+			continue
+		}
+		// Data aliases Recv's buffer, so don't hold on to it.
+		if pkt, ok := m.(derp.ReceivedPacket); ok && pkt.Source == p.serverPub && IsMeowedPacket(pkt.Data) {
+			return nil
+		}
+	}
+}
+
+func regionCode(r *tailcfg.DERPRegion) string {
+	return cmp.Or(r.RegionCode, r.RegionName, fmt.Sprint(r.RegionID))
+}
+
+// regionList formats regions for an error or log message.
+func regionList(cands []probeCandidate) string {
+	var sb strings.Builder
+	for i, c := range cands {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(&sb, "%v (%v)", c.reg.RegionID, regionCode(c.reg))
+	}
+	return sb.String()
+}

--- a/region_test.go
+++ b/region_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -412,3 +413,205 @@ func (c staticDERPMapCache) Get(string) (data []byte, etag string, storedAt time
 	return c.j, "", time.Now(), true
 }
 func (staticDERPMapCache) Put(string, []byte, string) error { return nil }
+
+func TestSearchCandidatesCoverage(t *testing.T) {
+	// Every region in the map is a candidate, however many there are:
+	// capping coverage would make a server that moved into the part of
+	// the map that fell off the end simply unfindable, which is the one
+	// thing a search exists to prevent. Only concurrency is bounded.
+	dm := &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{}}
+	for id := tailcfg.DERPRegionID(1); id <= 30; id++ {
+		dm.Regions[id] = &tailcfg.DERPRegion{
+			RegionID: id,
+			Nodes:    []*tailcfg.DERPNode{{HostName: fmt.Sprintf("r%d.example.com", id)}},
+		}
+	}
+	named := []probeCandidate{{dm.Regions[1], true}}
+	if got := len(searchCandidates(dm, named, false)); got != 30 {
+		t.Errorf("candidates for a 30-region map = %d; want 30 (all of them)", got)
+	}
+}
+
+func TestSearchCandidatesOrder(t *testing.T) {
+	at := func(id tailcfg.DERPRegionID, lat, lon float64) *tailcfg.DERPRegion {
+		return &tailcfg.DERPRegion{
+			RegionID:  id,
+			Latitude:  lat,
+			Longitude: lon,
+			Nodes:     []*tailcfg.DERPNode{{HostName: fmt.Sprintf("r%d.example.com", id)}},
+		}
+	}
+	ids := func(cands []probeCandidate) string {
+		var sb strings.Builder
+		for i, c := range cands {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			fmt.Fprintf(&sb, "%v", c.reg.RegionID)
+		}
+		return sb.String()
+	}
+
+	// A server that re-picks by latency lands near where it was, so the
+	// search works outward from the region the address names rather than
+	// up through the region IDs.
+	dm := &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
+		1: at(1, 40.7, -74.0),  // New York, the region the address names
+		2: at(2, 35.7, 139.7),  // Tokyo, far
+		3: at(3, 37.8, -122.4), // San Francisco, nearer
+	}}
+	if got, want := ids(searchCandidates(dm, []probeCandidate{{dm.Regions[1], true}}, false)), "1 3 2"; got != want {
+		t.Errorf("candidate order = %q; want %q (nearest first)", got, want)
+	}
+
+	// A region the map gives no coordinates for sorts after the ones it
+	// does, rather than being treated as a point in the Gulf of Guinea.
+	dm.Regions[4] = &tailcfg.DERPRegion{
+		RegionID: 4,
+		Nodes:    []*tailcfg.DERPNode{{HostName: "r4.example.com"}},
+	}
+	if got, want := ids(searchCandidates(dm, []probeCandidate{{dm.Regions[1], true}}, false)), "1 3 2 4"; got != want {
+		t.Errorf("candidate order with an uncoordinated region = %q; want %q", got, want)
+	}
+
+	// Nothing to measure from leaves the ID order alone.
+	noGeo := &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
+		1: {RegionID: 1, Nodes: []*tailcfg.DERPNode{{HostName: "a.example.com"}}},
+		2: {RegionID: 2, Nodes: []*tailcfg.DERPNode{{HostName: "b.example.com"}}},
+		3: {RegionID: 3, Nodes: []*tailcfg.DERPNode{{HostName: "c.example.com"}}},
+	}}
+	if got, want := ids(searchCandidates(noGeo, []probeCandidate{{noGeo.Regions[2], true}}, false)), "2 1 3"; got != want {
+		t.Errorf("candidate order without coordinates = %q; want %q", got, want)
+	}
+}
+
+func TestSearchTimeoutCoversEveryWave(t *testing.T) {
+	// The budget has to let the pool reach every region, since regions
+	// beyond maxProbeConcurrency are probed a wave at a time. Without
+	// that, raising the coverage cap would just move the cutoff from the
+	// candidate list into the clock.
+	for _, n := range []int{1, 4, 8, 9, 30, 64} {
+		waves := (n + maxProbeConcurrency - 1) / maxProbeConcurrency
+		if want := time.Duration(waves) * probeSlotTimeout; searchTimeout(n) < want {
+			t.Errorf("searchTimeout(%d) = %v; too short for %d waves of %v", n, searchTimeout(n), waves, probeSlotTimeout)
+		}
+	}
+	// A map small enough for one wave keeps the budget it always had.
+	if got := searchTimeout(4); got != probeSearchTimeoutMin {
+		t.Errorf("searchTimeout(4) = %v; want %v", got, probeSearchTimeoutMin)
+	}
+	// An implausibly large map is capped rather than left to run for
+	// minutes.
+	if got := searchTimeout(10000); got != probeSearchTimeoutMax {
+		t.Errorf("searchTimeout(10000) = %v; want %v", got, probeSearchTimeoutMax)
+	}
+}
+
+// fakeRegionCache is an in-memory [RegionCache] that counts its calls.
+type fakeRegionCache struct {
+	mu   sync.Mutex
+	m    map[key.NodePublic]tailcfg.DERPRegionID
+	gets int
+	puts int
+}
+
+func newFakeRegionCache() *fakeRegionCache {
+	return &fakeRegionCache{m: map[key.NodePublic]tailcfg.DERPRegionID{}}
+}
+
+func (c *fakeRegionCache) GetRegion(pub key.NodePublic) (tailcfg.DERPRegionID, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gets++
+	id, ok := c.m[pub]
+	return id, ok
+}
+
+func (c *fakeRegionCache) PutRegion(pub key.NodePublic, id tailcfg.DERPRegionID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.puts++
+	c.m[pub] = id
+	return nil
+}
+
+func (c *fakeRegionCache) counts() (gets, puts int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gets, c.puts
+}
+
+func TestDiscoverRegionCache(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	startServer(t, dm, srvPriv, 2, "server")
+
+	cache := newFakeRegionCache()
+	old := staleAddr(srvPriv, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	got, err := DiscoverRegion(ctx, old, key.NewNode(), dm, cache, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion: %v", err)
+	}
+	if ci, _ := ParseAddr(got); ci.RegionID != 2 {
+		t.Fatalf("corrected RegionID = %v; want 2", ci.RegionID)
+	}
+	// Finding the server is what makes the next search unnecessary, so
+	// the region has to be recorded even though the caller may never
+	// publish the corrected address.
+	if id, ok := cache.GetRegion(srvPriv.Public()); !ok || id != 2 {
+		t.Fatalf("cached region = %v, %v; want 2, true", id, ok)
+	}
+
+	// A later connection with the same stale address consults it.
+	gets, _ := cache.counts()
+	if _, err := DiscoverRegion(ctx, old, key.NewNode(), dm, cache, mkLogger(t, "discover2")); err != nil {
+		t.Fatalf("second DiscoverRegion: %v", err)
+	}
+	if nowGets, _ := cache.counts(); nowGets <= gets {
+		t.Error("second DiscoverRegion didn't consult the region cache")
+	}
+
+	// An entry pointing somewhere the server isn't costs a probe and is
+	// then corrected, which is why entries need no expiry.
+	cache.PutRegion(srvPriv.Public(), 1)
+	got, err = DiscoverRegion(ctx, old, key.NewNode(), dm, cache, mkLogger(t, "discover3"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion with a stale cache entry: %v", err)
+	}
+	if ci, _ := ParseAddr(got); ci.RegionID != 2 {
+		t.Errorf("corrected RegionID after a stale cache entry = %v; want 2", ci.RegionID)
+	}
+	if id, ok := cache.GetRegion(srvPriv.Public()); !ok || id != 2 {
+		t.Errorf("cache after correction = %v, %v; want 2, true", id, ok)
+	}
+}
+
+// TestDiscoverRegionCacheKeepsWorkingAddr covers a cached region that
+// answers alongside the one the address names. The cached region is a
+// hint, not an override: rewriting an address that still works would
+// invalidate an address that is published and correct.
+func TestDiscoverRegionCacheKeepsWorkingAddr(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	startServer(t, dm, srvPriv, 1, "server1")
+	startServer(t, dm, srvPriv, 2, "server2")
+
+	cache := newFakeRegionCache()
+	cache.PutRegion(srvPriv.Public(), 2)
+
+	old := staleAddr(srvPriv, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	got, err := DiscoverRegion(ctx, old, key.NewNode(), dm, cache, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion: %v", err)
+	}
+	if got != old {
+		t.Errorf("DiscoverRegion rewrote an address whose own region answers, to %v", got)
+	}
+}

--- a/region_test.go
+++ b/region_test.go
@@ -1,0 +1,414 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package tailcat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"tailscale.com/tailcfg"
+	"tailscale.com/tstest/integration"
+	"tailscale.com/types/key"
+)
+
+// twoRegionDERPMap runs two independent DERP+STUN servers and returns
+// one map holding both, as regions 1 and 2. RunDERPAndSTUN always hands
+// back region 1 with a node named "t1", so the second has to be
+// renumbered and renamed: netcheck identifies nodes by Name, and two
+// nodes sharing one would collide.
+func twoRegionDERPMap(t *testing.T) *tailcfg.DERPMap {
+	t.Helper()
+	a := integration.RunDERPAndSTUN(t, mkLogger(t, "derp1"), "127.0.0.1")
+	b := integration.RunDERPAndSTUN(t, mkLogger(t, "derp2"), "127.0.0.1")
+	r1, r2 := a.Regions[1], b.Regions[1]
+	if r1 == nil || r2 == nil {
+		t.Fatal("no region 1 in a test DERP map")
+	}
+	r1.RegionName = "Test Region 1"
+	r2.RegionID, r2.RegionCode, r2.RegionName = 2, "test2", "Test Region 2"
+	// RunDERPAndSTUN sets HostName to 127.0.0.1 on both relays. Dialing
+	// uses IPv4, which stays loopback; HostName is what embedded-address
+	// search uses to skip already-tried relays, so they must differ.
+	for _, n := range r1.Nodes {
+		n.HostName = "t1.test"
+	}
+	for _, n := range r2.Nodes {
+		n.RegionID, n.Name, n.HostName = 2, "t2", "t2.test"
+	}
+	return &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{1: r1, 2: r2}}
+}
+
+// staleAddr returns an address for priv's server naming regionID, whether
+// or not the server is really there: the situation auto-region exists
+// to repair.
+func staleAddr(priv key.NodePrivate, regionID tailcfg.DERPRegionID) Addr {
+	ci := &ConnInfo{
+		ServerPublic:      NodePublic{priv.Public()},
+		ServerDiscoPublic: DiscoPublicForNode(priv),
+		RegionID:          regionID,
+	}
+	return ci.Addr()
+}
+
+// startServer runs a server in the named region of dm, serving "hello"
+// on port 80.
+func startServer(t *testing.T, dm *tailcfg.DERPMap, priv key.NodePrivate, regionID tailcfg.DERPRegionID, name string) *Server {
+	t.Helper()
+	s := &Server{Key: priv, Logf: mkLogger(t, name), Region: dm.Regions[regionID]}
+	t.Cleanup(func() { s.Close() })
+	s.OnTCP = func(port uint16) func(net.Conn) {
+		if port != 80 {
+			return nil
+		}
+		return func(c net.Conn) {
+			io.WriteString(c, "hello")
+			c.Close()
+		}
+	}
+	if err := s.Start(); err != nil {
+		t.Fatalf("server %s Start: %v", name, err)
+	}
+	return s
+}
+
+func TestDiscoverRegion(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	startServer(t, dm, srvPriv, 2, "server")
+
+	old := staleAddr(srvPriv, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	got, err := DiscoverRegion(ctx, old, key.NewNode(), dm, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion: %v", err)
+	}
+	if got == old {
+		t.Fatal("DiscoverRegion returned the stale address unchanged")
+	}
+	ci, err := ParseAddr(got)
+	if err != nil {
+		t.Fatalf("parsing corrected address: %v", err)
+	}
+	if ci.RegionID != 2 {
+		t.Errorf("corrected RegionID = %v; want 2", ci.RegionID)
+	}
+	// Only the region may change; the identity is what makes the
+	// corrected address refer to the same server.
+	want, _ := ParseAddr(old)
+	if ci.ServerPublic != want.ServerPublic {
+		t.Errorf("ServerPublic = %v; want %v", ci.ServerPublic, want.ServerPublic)
+	}
+	if ci.ServerDiscoPublic != want.ServerDiscoPublic {
+		t.Errorf("ServerDiscoPublic = %v; want %v", ci.ServerDiscoPublic, want.ServerDiscoPublic)
+	}
+}
+
+func TestDiscoverRegionUnchanged(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	startServer(t, dm, srvPriv, 1, "server")
+
+	old := staleAddr(srvPriv, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	got, err := DiscoverRegion(ctx, old, key.NewNode(), dm, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion: %v", err)
+	}
+	if got != old {
+		t.Errorf("DiscoverRegion changed a correct address to %v", got)
+	}
+}
+
+// TestDiscoverRegionAllowlist pins the requirement that discovery probe
+// with the key the caller will really connect with. A server started
+// with an allowlist ignores a meow from any other key exactly the way an
+// absent server does, so probing with a throwaway key would report every
+// allowlisted server as missing.
+func TestDiscoverRegionAllowlist(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	s := startServer(t, dm, srvPriv, 2, "server")
+	clientPriv := key.NewNode()
+	s.AddAllowedClient(clientPriv.Public())
+
+	old := staleAddr(srvPriv, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	got, err := DiscoverRegion(ctx, old, clientPriv, dm, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion with the allowed key: %v", err)
+	}
+	if ci, _ := ParseAddr(got); ci.RegionID != 2 {
+		t.Fatalf("corrected RegionID = %v; want 2", ci.RegionID)
+	}
+
+	short, cancelShort := context.WithTimeout(ctx, 20*time.Second)
+	defer cancelShort()
+	if _, err := DiscoverRegion(short, old, key.NewNode(), dm, mkLogger(t, "discover-denied")); err == nil {
+		t.Error("DiscoverRegion with a key that isn't allowed = nil error; want failure")
+	}
+
+	// The probe registered the client with the server before the real
+	// connection did. Because both present the same derived disco key,
+	// the entry onMeow kept is the right one and the tunnel still works.
+	c := &Client{Server: got, Key: clientPriv, Logf: mkLogger(t, "client")}
+	t.Cleanup(func() { c.Close() })
+	c.DERPMapCache = staticDERPMapCacheForTest(t, dm)
+	PingForTest(t, s, c)
+	conn, err := c.DialTCPPort(ctx, 80)
+	if err != nil {
+		t.Fatalf("DialTCPPort: %v", err)
+	}
+	all, err := io.ReadAll(conn)
+	if err != nil || string(all) != "hello" {
+		t.Fatalf("read = %q, %v; want %q", all, err, "hello")
+	}
+}
+
+// TestDiscoPublicMatchesMagicsock guards the invariant that lets a raw
+// DERP probe stand in for a real client: the disco key it advertises
+// must be the one magicsock will present, or onMeow would record a key
+// the real client can no longer correct.
+func TestDiscoPublicMatchesMagicsock(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	s := startServer(t, dm, srvPriv, 1, "server")
+
+	clientPriv := key.NewNode()
+	c := &Client{Server: s.TailcatAddr(), Key: clientPriv, Logf: mkLogger(t, "client")}
+	t.Cleanup(func() { c.Close() })
+	WaitForDERPForTest(t, s, c)
+
+	got := c.lb.sys.MagicSock.Get().DiscoPublicKey()
+	if want := DiscoPublicForNode(clientPriv).DiscoPublic; got != want {
+		t.Errorf("magicsock disco key = %v; want DiscoPublicForNode = %v", got, want)
+	}
+}
+
+func TestDiscoverRegionEmbedded(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	startServer(t, dm, srvPriv, 2, "server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	// A "--full-address" address for region 1: self-contained, and just as
+	// stale as a short one once the server moves.
+	old, err := staleAddr(srvPriv, 1).Resolve(ctx, dm)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ci, _ := ParseAddr(old); len(ci.Region) == 0 {
+		t.Fatal("Resolve didn't embed the region")
+	}
+	got, err := DiscoverRegion(ctx, old, key.NewNode(), dm, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion: %v", err)
+	}
+	ci, err := ParseAddr(got)
+	if err != nil {
+		t.Fatalf("parsing corrected address: %v", err)
+	}
+	if ci.RegionID != 2 {
+		t.Errorf("corrected RegionID = %v; want 2", ci.RegionID)
+	}
+	if len(ci.Region) != 0 {
+		t.Errorf("corrected address embeds %d regions; want the short form", len(ci.Region))
+	}
+}
+
+func TestDiscoverRegionNotFound(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode() // no server ever started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	_, err := DiscoverRegion(ctx, staleAddr(srvPriv, 1), key.NewNode(), dm, mkLogger(t, "discover"))
+	if err == nil {
+		t.Fatal("DiscoverRegion found a server that doesn't exist")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("DiscoverRegion ran out the caller's context rather than its own budget: %v", err)
+	}
+	// A client missing from an allowlist sees the same silence, so the
+	// error has to raise that possibility too.
+	if !strings.Contains(err.Error(), "--allow") {
+		t.Errorf("error %q doesn't mention the allowlist possibility", err)
+	}
+}
+
+// TestDiscoverRegionMultiHomed covers a server reachable in more than
+// one region, which tailcat#7 contemplates. Every region it is in
+// answers a probe, so discovery must pick one and move on rather than
+// treat the extra answers as an error or wait for stragglers.
+func TestDiscoverRegionMultiHomed(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	startServer(t, dm, srvPriv, 1, "server1")
+	startServer(t, dm, srvPriv, 2, "server2")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Naming a region the server really is in: nothing moved.
+	old := staleAddr(srvPriv, 1)
+	got, err := DiscoverRegion(ctx, old, key.NewNode(), dm, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion: %v", err)
+	}
+	if got != old {
+		t.Errorf("DiscoverRegion changed an address naming a live region to %v", got)
+	}
+
+	// Naming a region it isn't in: either of the others is a valid answer.
+	got, err = DiscoverRegion(ctx, staleAddr(srvPriv, 3), key.NewNode(), dm, mkLogger(t, "discover"))
+	if err != nil {
+		t.Fatalf("DiscoverRegion from an unknown region: %v", err)
+	}
+	if ci, _ := ParseAddr(got); ci.RegionID != 1 && ci.RegionID != 2 {
+		t.Errorf("corrected RegionID = %v; want 1 or 2", ci.RegionID)
+	}
+}
+
+func TestClientAutoRegion(t *testing.T) {
+	t.Parallel()
+	dm := twoRegionDERPMap(t)
+	srvPriv := key.NewNode()
+	s := startServer(t, dm, srvPriv, 2, "server")
+
+	var gotAddr Addr
+	var gotRegion tailcfg.DERPRegionID
+	var calls int
+	c := &Client{
+		Server:       staleAddr(srvPriv, 1),
+		Logf:         mkLogger(t, "client"),
+		AutoRegion:   true,
+		DERPMapCache: staticDERPMapCacheForTest(t, dm),
+		OnRegionDiscovered: func(b Addr, r *tailcfg.DERPRegion) {
+			calls++
+			gotAddr, gotRegion = b, r.RegionID
+		},
+	}
+	t.Cleanup(func() { c.Close() })
+
+	pub := c.PublicKey()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if _, err := c.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("OnRegionDiscovered called %d times; want 1", calls)
+	}
+	if gotRegion != 2 {
+		t.Errorf("discovered region = %v; want 2", gotRegion)
+	}
+	if got, ok := c.DiscoveredServer(); !ok || got != gotAddr {
+		t.Errorf("DiscoveredServer = %v, %v; want %v, true", got, ok, gotAddr)
+	}
+	// The identity must survive discovery: it's what the server
+	// allowlists, and what its address is derived from.
+	if got := c.PublicKey(); got != pub {
+		t.Errorf("PublicKey changed across discovery: %v, was %v", got, pub)
+	}
+	conn, err := c.DialTCPPort(ctx, 80)
+	if err != nil {
+		t.Fatalf("DialTCPPort: %v", err)
+	}
+	all, err := io.ReadAll(conn)
+	if err != nil || string(all) != "hello" {
+		t.Fatalf("read = %q, %v; want %q", all, err, "hello")
+	}
+	_ = s
+}
+
+func TestSearchCandidates(t *testing.T) {
+	mk := func(id tailcfg.DERPRegionID, host string) *tailcfg.DERPRegion {
+		return &tailcfg.DERPRegion{
+			RegionID: id,
+			Nodes:    []*tailcfg.DERPNode{{HostName: host}},
+		}
+	}
+	dm := &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
+		1: mk(1, "a.example.com"),
+		2: mk(2, "b.example.com"),
+		3: mk(3, "c.example.com"),
+	}}
+	// desc renders each candidate as its region ID, with a "*" for the
+	// ones the address already names.
+	desc := func(cands []probeCandidate) string {
+		var sb strings.Builder
+		for i, c := range cands {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			fmt.Fprintf(&sb, "%v", c.reg.RegionID)
+			if c.named {
+				sb.WriteString("*")
+			}
+		}
+		return sb.String()
+	}
+	named := func(r *tailcfg.DERPRegion) []probeCandidate {
+		return []probeCandidate{{r, true}}
+	}
+
+	// The named region is probed again, first, so that a confirm stage
+	// that only ran slow doesn't get read as the server having moved.
+	if got, want := desc(searchCandidates(dm, named(dm.Regions[2]), false)), "2* 1 3"; got != want {
+		t.Errorf("candidates for an address naming region 2 = %q; want %q", got, want)
+	}
+
+	// In-process test relays share 127.0.0.1 as HostName. Map-derived
+	// regions are matched by ID, so both must still be probed.
+	sameHost := &tailcfg.DERPMap{Regions: map[tailcfg.DERPRegionID]*tailcfg.DERPRegion{
+		1: mk(1, "127.0.0.1"),
+		2: mk(2, "127.0.0.1"),
+	}}
+	if got, want := desc(searchCandidates(sameHost, named(sameHost.Regions[1]), false)), "1* 2"; got != want {
+		t.Errorf("candidates when map regions share a hostname = %q; want %q", got, want)
+	}
+
+	// An embedded address's region IDs are synthesized as 1..N, so the map
+	// entry for the relay it names is recognized by hostname and not
+	// probed twice. The map's own region 1 is a different relay and is.
+	if got, want := desc(searchCandidates(dm, named(mk(1, "C.EXAMPLE.COM")), true)), "1* 1 2"; got != want {
+		t.Errorf("candidates for an embedded address = %q; want %q", got, want)
+	}
+}
+
+// staticDERPMapCacheForTest makes dm the answer to any DERP map fetch,
+// so a test client resolves regions without a map server.
+func staticDERPMapCacheForTest(t *testing.T, dm *tailcfg.DERPMap) DERPMapCache {
+	t.Helper()
+	j, err := json.Marshal(dm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return staticDERPMapCache{j}
+}
+
+type staticDERPMapCache struct{ j []byte }
+
+func (c staticDERPMapCache) Get(string) (data []byte, etag string, storedAt time.Time, ok bool) {
+	return c.j, "", time.Now(), true
+}
+func (staticDERPMapCache) Put(string, []byte, string) error { return nil }

--- a/tailcat.go
+++ b/tailcat.go
@@ -1524,9 +1524,23 @@ type Client struct {
 	// before the client's first use.
 	DERPMapCache DERPMapCache
 
-	lb       *locoBackend
-	ci       ConnInfo      // of server
-	meowWait chan struct{} // closed on first meowed message from server
+	// AutoRegion enables searching the DERP map for the server if it
+	// doesn't answer in the region its address names, as happens when a
+	// server run with "genkey --region=auto" restarts into a different
+	// region. See [DiscoverRegion]. If set, it must be set before the
+	// client's first use.
+	AutoRegion bool
+
+	// OnRegionDiscovered, if non-nil, is called when AutoRegion finds
+	// the server in a region other than the one its address named, with
+	// an updated address and the region it was found in. Publishing that
+	// address saves later clients the search.
+	OnRegionDiscovered func(Addr, *tailcfg.DERPRegion)
+
+	lb         *locoBackend
+	ci         ConnInfo      // of server
+	meowWait   chan struct{} // closed on first meowed message from server
+	discovered Addr          // set by AutoRegion if the server had moved; guarded by startMu
 
 	serverAddr netip.Addr
 
@@ -1571,7 +1585,7 @@ func (c *Client) initLocked() error {
 	if logf == nil {
 		logf = log.Printf
 	}
-	ci, err := ParseAddr(c.Server)
+	ci, err := ParseAddr(cmp.Or(c.discovered, c.Server))
 	if err != nil {
 		return err
 	}
@@ -1692,6 +1706,66 @@ type PingResult struct {
 	Latency time.Duration
 }
 
+// derpMapOpts returns the DERP map options implied by the client's
+// configuration, for [ConnInfo.Expand] and [DiscoverRegion].
+func (c *Client) derpMapOpts() []any {
+	var opts []any
+	if c.DERPMapURL != "" {
+		opts = append(opts, DERPMapURL(c.DERPMapURL))
+	}
+	if c.DERPMapCache != nil {
+		opts = append(opts, c.DERPMapCache)
+	}
+	return opts
+}
+
+// discoverRegionLocked looks for the server in the DERP map if it isn't
+// in the region its address names, recording the corrected address for
+// initLocked to use. It runs before initLocked so that the rest of the
+// client only ever sees a region the server answered in, and so that its
+// probes are all finished before magicsock connects: DERP delivers a node
+// key's traffic to whichever of its connections wrote last, so a probe
+// still open to the winning region would fight the real connection.
+// c.startMu must be held.
+func (c *Client) discoverRegionLocked(ctx context.Context, opts []any) error {
+	logf := c.Logf
+	if logf == nil {
+		logf = log.Printf
+	}
+	addr, err := DiscoverRegion(ctx, c.Server, c.nodeKeyLocked(), append(slices.Clip(opts), logf)...)
+	if err != nil {
+		return err
+	}
+	c.discovered = addr
+	if addr == c.Server || c.OnRegionDiscovered == nil {
+		return nil
+	}
+	ci, err := ParseAddr(addr)
+	if err != nil {
+		return err
+	}
+	reg := &tailcfg.DERPRegion{RegionID: ci.RegionID}
+	if dm, err := FetchDERPMap(ctx, opts...); err == nil {
+		if r, ok := dm.Regions[ci.RegionID]; ok {
+			reg = r
+		}
+	}
+	c.OnRegionDiscovered(addr, reg)
+	return nil
+}
+
+// DiscoveredServer returns an updated address for the server if
+// [Client.AutoRegion] found it in a region other than the one its
+// original address named.
+func (c *Client) DiscoveredServer() (Addr, bool) {
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+	if c.discovered == "" || c.discovered == c.Server {
+		return "", false
+	}
+	return c.discovered, true
+}
+
 // ensureStarted brings up the client's network stack on first use:
 // it resolves the server's DERP region if the Addr didn't embed
 // it (possibly fetching the DERP map over the network, bounded by
@@ -1704,15 +1778,14 @@ func (c *Client) ensureStarted(ctx context.Context) error {
 	if c.started {
 		return nil
 	}
+	opts := c.derpMapOpts()
+	if c.AutoRegion && c.discovered == "" {
+		if err := c.discoverRegionLocked(ctx, opts); err != nil {
+			return err
+		}
+	}
 	if err := c.initLocked(); err != nil {
 		return err
-	}
-	var opts []any
-	if c.DERPMapURL != "" {
-		opts = append(opts, DERPMapURL(c.DERPMapURL))
-	}
-	if c.DERPMapCache != nil {
-		opts = append(opts, c.DERPMapCache)
 	}
 	if err := c.ci.Expand(ctx, opts...); err != nil {
 		return err

--- a/tailcat.go
+++ b/tailcat.go
@@ -1531,6 +1531,13 @@ type Client struct {
 	// client's first use.
 	AutoRegion bool
 
+	// RegionCache, if non-nil, remembers where AutoRegion found the
+	// server, so later connections with the same stale address look
+	// there first instead of searching the map again. If nil, every
+	// connection that needs a search pays for one. If set, it must be
+	// set before the client's first use.
+	RegionCache RegionCache
+
 	// OnRegionDiscovered, if non-nil, is called when AutoRegion finds
 	// the server in a region other than the one its address named, with
 	// an updated address and the region it was found in. Publishing that
@@ -1732,7 +1739,14 @@ func (c *Client) discoverRegionLocked(ctx context.Context, opts []any) error {
 	if logf == nil {
 		logf = log.Printf
 	}
-	addr, err := DiscoverRegion(ctx, c.Server, c.nodeKeyLocked(), append(slices.Clip(opts), logf)...)
+	// opts is reused below for the DERP map fetch, which rejects option
+	// types it doesn't know, so the region cache goes only to the call
+	// that understands it.
+	discOpts := append(slices.Clip(opts), logf)
+	if c.RegionCache != nil {
+		discOpts = append(discOpts, c.RegionCache)
+	}
+	addr, err := DiscoverRegion(ctx, c.Server, c.nodeKeyLocked(), discOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**A stop-gap, not the fix.** The real fix is server-side: a saved key
should record a concrete region and bind to it at every startup, so a
published token stays true. That needs the server to change, and does
nothing for a token already published or a server already running.

This is entirely client-side, and works against what is deployed today.

### Backward compatible with deployed servers

Not just "servers need no change" — this branch **changes no server code
at all**, so a running server cannot tell the difference.

- Every hunk in `tailcat.go` is inside `Client`. `Server`, `locoBackend`,
  `onMeow` and `advertiseEndpoints` are untouched.
- `wire.go` and `disco.go` are untouched: the token layout and the meow
  packets are byte-identical, and a corrected token is the same short
  RegionID form the server already emits.
- A probe is indistinguishable from a client connecting, because it is
  one — same meow, same node key.
- The one new packet, a disco ping that draws `NotHere` out of the relay,
  is handled by magicsock, not tailcat (`OnDERPRecv` sees only non-disco
  packets). An unknown peer's disco is dropped, so it can't get past
  `--allow`.

`TestDiscoverRegionAllowlist` still comes back empty against a prober
sending that ping, and `TestClientAutoRegion` completes a real tunnel
session against a server that received every new packet. Since no server
code changed, those tests are the compatibility test.

The one exception is pre-existing and explicit: a token minted before
servers carried a separate disco key can't be searched, and says so.

### What it does

A server keyed with `genkey --region=auto` re-picks its region at every
startup, so a published token can name one it has since left; the client
then just times out. The keys in the token still identify the server, so
`--auto-region` keeps them, asks candidate regions whether the server is
there, connects, and prints the corrected token on stderr.

    tailcat ping --auto-region --verbose tcOLD...
    tailcat ssh  --auto-region tcOLD...

The search covers every region in the map, however large it grows; only
concurrency is bounded, at eight at a time. It runs outward from the
region the token names, since a server that re-picks by latency usually
lands near where it was, and asks each relay outright whether it has the
server, which is a round trip rather than a timeout. Where it found the
server is cached in `$XDG_CACHE_HOME/tailcat/regions.json`, so a moved
server costs one search and not one per `ssh` or `cp`.

### What it does not fix

A published token is still wrong until someone stores the corrected one;
only clients carrying this change benefit; a server on a relay outside
the map stays unreachable. The region remains a mutable fact inside an
immutable address — the actual defect, still open.

One consequence worth naming: the relay now tells a token-holder which
region has the server, where an unauthorized holder previously saw the
same silence either way. Not a new capability — any DERP client with the
node key could always ask — but tailcat now asks by default under the
flag.

### Testing

`region_test.go` covers a moved server, an unmoved one, an embedded
token, an allowlisted server, a multi-homed server, the not-found error,
the region cache, full coverage of a thirty-region map, ordering, and
the search budget. `cmd/tailcat/autoregion_e2e_test.go` drives the real
binary with a negative control and asserts the notice never reaches
stdout. Clean under `-race`.

Rebased past "harden validation of arguments passed to ssh/scp child
processes": `sshProxyCommand` keeps its hardened args-slice form and
quoting, with the flags a ProxyCommand carries into the child bundled in
a `proxyOpts` struct so `--auto-region` can join them.

Updates #7 — the client-search part; multi-region servers and lat/long
in tokens are untouched.
