### PR TITLE
harden validation of arguments passed to ssh/scp child processes

### DIFF
--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -14,6 +14,41 @@ import (
 	"github.com/peterbourgon/ff/v4/ffhelp"
 )
 
+func TestClassifyAddrBlobArg(t *testing.T) {
+	const blob = "tcomFwWCAAAQIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH2FpCg"
+	for _, tt := range []struct {
+		name, arg     string
+		wantBlob      string
+		wantDNS       string
+		wantErrSubstr string
+	}{
+		{"blob", blob, blob, "", ""},
+		{"DNS name", "server.example.com", "", "server.example.com", ""},
+		{"absolute DNS name", "server.example.com.", "", "server.example.com.", ""},
+		{"DNS name beginning with tc", "tc-server.example.com", "", "tc-server.example.com", ""},
+		{"blob with period", blob + ".", "", "", "refusing DNS lookup"},
+		{"blob as interior label", "prefix." + blob + ".example", "", "", "refusing DNS lookup"},
+		{"invalid DNS character", "server_name.example", "", "", "invalid character"},
+		{"empty DNS label", "server..example", "", "", "empty label"},
+		{"long DNS label", strings.Repeat("a", 64) + ".example", "", "", "longer than 63 bytes"},
+		{"neither", "not-a-blob", "", "", "neither a valid connection blob nor a DNS name"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBlob, gotDNS, err := classifyAddrBlobArg(tt.arg)
+			if string(gotBlob) != tt.wantBlob || gotDNS != tt.wantDNS {
+				t.Errorf("classifyAddrBlobArg(%q) = %q, %q; want %q, %q", tt.arg, gotBlob, gotDNS, tt.wantBlob, tt.wantDNS)
+			}
+			if tt.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("classifyAddrBlobArg(%q): %v", tt.arg, err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Fatalf("classifyAddrBlobArg(%q) error = %v; want error containing %q", tt.arg, err, tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
 // TestHelpListsCommandTree verifies that the generated root help
 // mentions every subcommand and the global flags, the declarative
 // help dump that motivated the ff port.

--- a/cmd/tailcat/cp.go
+++ b/cmd/tailcat/cp.go
@@ -58,27 +58,42 @@ func clientCPMode(recursive, preserve bool, portOrIPPort string, args []string) 
 	if len(args) < 2 {
 		return usagef("cp requires at least one source and a target")
 	}
+	portOrIPPort, err := validatedSSHPort(portOrIPPort)
+	if err != nil {
+		return err
+	}
 
-	// Translate <addrblob>:path arguments to scp host:path ones. The
-	// host handed to scp is a short deterministic label (see
-	// sshDestHost); the blob itself does the routing, inside the
-	// ProxyCommand.
+	// Find the server named by the remote arguments before translating
+	// them to scp host:path arguments.
 	blob := ""
-	scpArgs := make([]string, 0, len(args))
 	for _, arg := range args {
-		host, path, ok := splitRemoteArg(arg)
+		host, _, ok := splitRemoteArg(arg)
 		if !ok {
-			scpArgs = append(scpArgs, arg)
 			continue
 		}
 		if blob != "" && host != blob {
 			return usagef("all remote paths must name the same server (%q and %q differ)", blob, host)
 		}
 		blob = host
-		scpArgs = append(scpArgs, sshDestHost(host)+":"+path)
 	}
 	if blob == "" {
 		return usagef("no remote <addrblob>:path argument; nothing to copy through tailcat")
+	}
+	blob, err = validatedConnBlob(blob)
+	if err != nil {
+		return err
+	}
+
+	// Give scp a short deterministic host label; the validated blob does
+	// the actual routing inside ProxyCommand.
+	scpArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		_, path, ok := splitRemoteArg(arg)
+		if !ok {
+			scpArgs = append(scpArgs, arg)
+			continue
+		}
+		scpArgs = append(scpArgs, sshDestHost(blob)+":"+path)
 	}
 
 	exe, err := os.Executable()
@@ -89,13 +104,17 @@ func clientCPMode(recursive, preserve bool, portOrIPPort string, args []string) 
 	if err != nil {
 		log.Fatalf("no scp found in $PATH: %v", err)
 	}
+	proxyCommand, err := sshProxyCommand(exe, *flagKey, *flagDERPMapURL, blob, portOrIPPort)
+	if err != nil {
+		return err
+	}
 	argv := []string{
 		scpExe,
 		"-o", "UpdateHostKeys no",
 		"-o", "StrictHostKeyChecking no",
 		"-o", "UserKnownHostsFile " + os.DevNull,
 		"-o", "LogLevel ERROR",
-		"-o", "ProxyCommand=" + sshProxyCommand(exe, *flagKey, *flagDERPMapURL, blob, portOrIPPort),
+		"-o", "ProxyCommand=" + proxyCommand,
 	}
 	if recursive {
 		argv = append(argv, "-r")
@@ -103,6 +122,7 @@ func clientCPMode(recursive, preserve bool, portOrIPPort string, args []string) 
 	if preserve {
 		argv = append(argv, "-p")
 	}
+	argv = append(argv, "--")
 	argv = append(argv, scpArgs...)
 	err = execSSH(scpExe, argv)
 	log.Fatalf("failed to run scp: %v", err)

--- a/cmd/tailcat/cp_test.go
+++ b/cmd/tailcat/cp_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -56,6 +57,13 @@ func TestCPUsageErrors(t *testing.T) {
 		if !errors.As(err, &ue) {
 			t.Errorf("%s: err = %v; want a usageError", tt.name, err)
 		}
+	}
+}
+
+func TestCPRejectsInvalidConnBlob(t *testing.T) {
+	err := clientCPMode(false, false, "22", []string{"local.txt", "tc%:remote.txt"})
+	if err == nil || !strings.Contains(err.Error(), "base64 decode") {
+		t.Fatalf("clientCPMode error = %v; want an invalid base64 error", err)
 	}
 }
 

--- a/cmd/tailcat/files_e2e_test.go
+++ b/cmd/tailcat/files_e2e_test.go
@@ -21,6 +21,10 @@ import (
 // commands, returning its combined output and error.
 func runSFTPBatch(t *testing.T, e *testEnv, blob, batch string) ([]byte, error) {
 	t.Helper()
+	proxyCommand, err := sshProxyCommand(e.bin, "new", e.derpMapURL, blob, "22")
+	if err != nil {
+		t.Fatal(err)
+	}
 	batchFile := filepath.Join(t.TempDir(), "batch")
 	if err := os.WriteFile(batchFile, []byte(batch), 0600); err != nil {
 		t.Fatal(err)
@@ -29,7 +33,7 @@ func runSFTPBatch(t *testing.T, e *testEnv, blob, batch string) ([]byte, error) 
 		"-o", "StrictHostKeyChecking no",
 		"-o", "UserKnownHostsFile "+os.DevNull,
 		"-o", "LogLevel ERROR",
-		"-o", "ProxyCommand="+sshProxyCommand(e.bin, "new", e.derpMapURL, blob, "22"),
+		"-o", "ProxyCommand="+proxyCommand,
 		"-b", batchFile,
 		sshDestHost(blob))
 	cmd.Env = e.env

--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/peterbourgon/ff/v4"
@@ -65,8 +66,9 @@ func clientSSHMode(portOrIPPort string, args []string) error {
 	if len(args) == 0 {
 		return usagef("ssh requires a [user@]<addrblob> destination argument")
 	}
-	if ip, err := netip.ParseAddr(portOrIPPort); err == nil {
-		portOrIPPort = netip.AddrPortFrom(ip, 22).String()
+	portOrIPPort, err := validatedSSHPort(portOrIPPort)
+	if err != nil {
+		return err
 	}
 	dst := args[0] // either a derpaddr alone or "user@<derpaddr>"
 	cmdArgs := args[1:]
@@ -75,6 +77,10 @@ func clientSSHMode(portOrIPPort string, args []string) error {
 	if !hasUser {
 		connBlobStr = sshUser
 		sshUser = ""
+	}
+	connBlobStr, err = validatedConnBlob(connBlobStr)
+	if err != nil {
+		return err
 	}
 	exe, err := os.Executable()
 	if err != nil {
@@ -88,13 +94,18 @@ func clientSSHMode(portOrIPPort string, args []string) error {
 	if sshUser != "" {
 		sshDst = sshUser + "@" + sshDst
 	}
+	proxyCommand, err := sshProxyCommand(exe, *flagKey, *flagDERPMapURL, connBlobStr, portOrIPPort)
+	if err != nil {
+		return err
+	}
 	argv := []string{
 		sshExe,
 		"-o", "UpdateHostKeys no",
 		"-o", "StrictHostKeyChecking no",
 		"-o", "UserKnownHostsFile " + os.DevNull,
 		"-o", "LogLevel ERROR",
-		"-o", "ProxyCommand=" + sshProxyCommand(exe, *flagKey, *flagDERPMapURL, connBlobStr, portOrIPPort),
+		"-o", "ProxyCommand=" + proxyCommand,
+		"--",
 		sshDst,
 	}
 	argv = append(argv, cmdArgs...)
@@ -103,28 +114,96 @@ func clientSSHMode(portOrIPPort string, args []string) error {
 	return nil
 }
 
+// validatedSSHPort validates and canonicalizes the port or IP:port passed to
+// tailcat's child ProxyCommand. A bare IP means port 22.
+func validatedSSHPort(v string) (string, error) {
+	if port, err := strconv.ParseUint(v, 10, 16); err == nil && port != 0 {
+		return strconv.FormatUint(port, 10), nil
+	}
+	if ip, err := netip.ParseAddr(v); err == nil {
+		return netip.AddrPortFrom(ip, 22).String(), nil
+	}
+	if ipPort, err := netip.ParseAddrPort(v); err == nil && ipPort.Port() != 0 {
+		return ipPort.String(), nil
+	}
+	return "", usagef("invalid port or IP:port %q", v)
+}
+
+// validatedConnBlob resolves arg if it is a DNS name and verifies that the
+// result is a valid connection blob before it is handed to ssh or scp.
+func validatedConnBlob(arg string) (string, error) {
+	connBlob := tailcat.ConnBlob(arg)
+	if strings.Contains(arg, ".") {
+		connBlob = addrBlobArg(arg)
+	}
+	if _, err := tailcat.ParseConnBlob(connBlob); err != nil {
+		return "", fmt.Errorf("invalid connection blob %q: %w", arg, err)
+	}
+	return string(connBlob), nil
+}
+
 // sshProxyCommand returns the command passed to OpenSSH to connect the SSH
 // client to a tailcat server. The command is run by OpenSSH, so values that
 // can contain shell-special characters must be quoted.
-func sshProxyCommand(exe, keyName, derpMapURL, connBlob, portOrIPPort string) string {
-	if runtime.GOOS == "windows" {
-		// Plain quotes without Go's %q backslash escaping: the
-		// executable is a Windows path whose backslashes must survive
-		// both cmd.exe (which Win32-OpenSSH uses to run ProxyCommand)
-		// and the child's own command line parsing.
-		exe = "\"" + exe + "\""
-	}
-	cmd := exe
-	// No --key flag at all when unset: the shell turns --key="" into
-	// --key=, which ff parses by consuming the next argument (the
-	// address blob) as the flag's value.
+func sshProxyCommand(exe, keyName, derpMapURL, connBlob, portOrIPPort string) (string, error) {
+	args := []string{exe}
+	// No --key flag at all when unset: ff parses --key= by consuming the
+	// connection blob as the flag's value.
 	if keyName != "" {
-		cmd += fmt.Sprintf(" --key=%q", keyName)
+		args = append(args, "--key="+keyName)
 	}
 	if derpMapURL != tailcat.DefaultDERPMapURL {
-		cmd += fmt.Sprintf(" --derpmap-url=%q", derpMapURL)
+		args = append(args, "--derpmap-url="+derpMapURL)
 	}
-	return fmt.Sprintf("%s %s %s", cmd, connBlob, portOrIPPort)
+	args = append(args, connBlob, portOrIPPort)
+	if runtime.GOOS == "windows" {
+		return proxyCommandJoinWindows(args)
+	}
+	return proxyCommandJoinUnix(args)
+}
+
+// proxyCommandJoinUnix quotes args for the POSIX shell OpenSSH uses to run a
+// ProxyCommand. Percent signs are doubled for OpenSSH's own token expansion;
+// it changes %% back to % before handing the command to the shell.
+func proxyCommandJoinUnix(args []string) (string, error) {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		if strings.ContainsAny(arg, "\r\n\x00") {
+			return "", fmt.Errorf("ProxyCommand argument contains a control character: %q", arg)
+		}
+		arg = strings.ReplaceAll(arg, "%", "%%")
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+	}
+	return strings.Join(quoted, " "), nil
+}
+
+// proxyCommandJoinWindows quotes args for cmd.exe, which Win32-OpenSSH uses
+// to run a ProxyCommand. cmd.exe expands %variables% and, depending on
+// configuration, !variables! even inside quotes, so reject those characters
+// rather than claiming they can be safely escaped through both OpenSSH and
+// cmd.exe.
+func proxyCommandJoinWindows(args []string) (string, error) {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		if strings.ContainsAny(arg, "\"%!\r\n\x00") {
+			return "", fmt.Errorf("ProxyCommand argument contains a character unsafe for cmd.exe: %q", arg)
+		}
+		quoted[i] = quoteWindowsCommandArg(arg)
+	}
+	return strings.Join(quoted, " "), nil
+}
+
+// quoteWindowsCommandArg always double-quotes arg, protecting cmd.exe
+// metacharacters, and doubles trailing backslashes as required by the Windows
+// argv parser used by the tailcat child. Embedded quotes are rejected above
+// because cmd.exe and that argv parser assign them incompatible meanings.
+func quoteWindowsCommandArg(arg string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	b.WriteString(arg)
+	b.WriteString(strings.Repeat("\\", len(arg)-len(strings.TrimRight(arg, "\\"))))
+	b.WriteByte('"')
+	return b.String()
 }
 
 // sshDestHost returns the hostname to give the system ssh client as the

--- a/cmd/tailcat/ssh_test.go
+++ b/cmd/tailcat/ssh_test.go
@@ -6,12 +6,35 @@
 package main
 
 import (
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/tailscale/tailcat"
 )
+
+func TestSSHRejectsInvalidConnBlob(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		blob    string
+		wantErr string
+	}{
+		{"missing prefix", "not-a-token", `doesn't start with "tc"`},
+		{"invalid base64", "tc%", "base64 decode"},
+		{"invalid CBOR", "tc" + base64.RawURLEncoding.EncodeToString([]byte("not CBOR")), "CBOR unmarshal"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := clientSSHMode("22", []string{tt.blob})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("clientSSHMode(%q) error = %v; want an error containing %q", tt.blob, err, tt.wantErr)
+			}
+		})
+	}
+}
 
 func TestSSHProxyCommandDERPMap(t *testing.T) {
 	const (
@@ -21,19 +44,26 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 		port = "22"
 		url  = "https://derp.example.com/derpmap.json"
 	)
-	wantExe := exe
-	if runtime.GOOS == "windows" {
-		wantExe = `"` + exe + `"`
+	got, err := sshProxyCommand(exe, key, url, blob, port)
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	got := sshProxyCommand(exe, key, url, blob, port)
-	want := wantExe + ` --key="client-default" --derpmap-url="https://derp.example.com/derpmap.json" tc-short-blob 22`
+	want := `'` + exe + `' '--key=client-default' '--derpmap-url=https://derp.example.com/derpmap.json' 'tc-short-blob' '22'`
+	if runtime.GOOS == "windows" {
+		want = `"/path/to/tailcat" "--key=client-default" "--derpmap-url=https://derp.example.com/derpmap.json" "tc-short-blob" "22"`
+	}
 	if got != want {
 		t.Errorf("sshProxyCommand with custom DERP map = %q; want %q", got, want)
 	}
 
-	got = sshProxyCommand(exe, key, tailcat.DefaultDERPMapURL, blob, port)
-	want = wantExe + ` --key="client-default" tc-short-blob 22`
+	got, err = sshProxyCommand(exe, key, tailcat.DefaultDERPMapURL, blob, port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = `'` + exe + `' '--key=client-default' 'tc-short-blob' '22'`
+	if runtime.GOOS == "windows" {
+		want = `"/path/to/tailcat" "--key=client-default" "tc-short-blob" "22"`
+	}
 	if got != want {
 		t.Errorf("sshProxyCommand with default DERP map = %q; want %q", got, want)
 	}
@@ -41,10 +71,92 @@ func TestSSHProxyCommandDERPMap(t *testing.T) {
 	// No --key flag at all when unset. The shell would collapse
 	// --key="" to --key=, which ff parses by consuming the next
 	// argument, the address blob.
-	got = sshProxyCommand(exe, "", tailcat.DefaultDERPMapURL, blob, port)
-	want = wantExe + ` tc-short-blob 22`
+	got, err = sshProxyCommand(exe, "", tailcat.DefaultDERPMapURL, blob, port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = `'` + exe + `' 'tc-short-blob' '22'`
+	if runtime.GOOS == "windows" {
+		want = `"/path/to/tailcat" "tc-short-blob" "22"`
+	}
 	if got != want {
 		t.Errorf("sshProxyCommand with no key = %q; want %q", got, want)
+	}
+}
+
+func TestProxyCommandJoinUnix(t *testing.T) {
+	tmpDir := t.TempDir()
+	injected := filepath.Join(tmpDir, "injected")
+	program := filepath.Join(tmpDir, "print args; false")
+	if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf '<%s>\\n' \"$@\"\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	key := `key $(touch ` + injected + `) ' " $HOME`
+	url := "https://example.invalid/`touch " + injected + "`?x=%h&y=two words"
+
+	command, err := proxyCommandJoinUnix([]string{program, "--key=" + key, "--derpmap-url=" + url, "tc-safe", "22"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate OpenSSH's documented %% -> % expansion before it invokes the
+	// shell. The shell must then see every dynamic value as one literal arg.
+	command = strings.ReplaceAll(command, "%%", "%")
+	out, err := exec.Command("sh", "-c", command).Output()
+	if err != nil {
+		t.Fatalf("running ProxyCommand: %v", err)
+	}
+	want := "<--key=" + key + ">\n<--derpmap-url=" + url + ">\n<tc-safe>\n<22>\n"
+	if string(out) != want {
+		t.Fatalf("ProxyCommand output = %q; want %q", out, want)
+	}
+	if _, err := os.Stat(injected); !os.IsNotExist(err) {
+		t.Fatalf("shell command substitution ran; Stat(%q) error = %v", injected, err)
+	}
+	if _, err := proxyCommandJoinUnix([]string{"line\nbreak"}); err == nil {
+		t.Fatal("proxyCommandJoinUnix accepted a newline")
+	}
+}
+
+func TestProxyCommandJoinWindows(t *testing.T) {
+	got, err := proxyCommandJoinWindows([]string{`C:\Program Files\tailcat.exe`, `--key=a&b`, `tc-safe`, `22`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `"C:\Program Files\tailcat.exe" "--key=a&b" "tc-safe" "22"`
+	if got != want {
+		t.Fatalf("proxyCommandJoinWindows = %q; want %q", got, want)
+	}
+	if got := quoteWindowsCommandArg(`C:\tailcat\`); got != `"C:\tailcat\\"` {
+		t.Errorf("quoteWindowsCommandArg with trailing slash = %q", got)
+	}
+	for _, arg := range []string{`has"quote`, "has%percent", "has!bang", "has\nnewline", "has\x00nul"} {
+		if _, err := proxyCommandJoinWindows([]string{arg}); err == nil {
+			t.Errorf("proxyCommandJoinWindows accepted unsafe argument %q", arg)
+		}
+	}
+}
+
+func TestValidatedSSHPort(t *testing.T) {
+	for _, tt := range []struct {
+		in, want string
+		valid    bool
+	}{
+		{"22", "22", true},
+		{"0022", "22", true},
+		{"192.0.2.1", "192.0.2.1:22", true},
+		{"192.0.2.1:2222", "192.0.2.1:2222", true},
+		{"2001:db8::1", "[2001:db8::1]:22", true},
+		{"[2001:db8::1]:2222", "[2001:db8::1]:2222", true},
+		{"", "", false},
+		{"0", "", false},
+		{"65536", "", false},
+		{"22; touch /tmp/injected", "", false},
+		{"example.com:22", "", false},
+	} {
+		got, err := validatedSSHPort(tt.in)
+		if (err == nil) != tt.valid || got != tt.want {
+			t.Errorf("validatedSSHPort(%q) = %q, %v; want %q, valid=%v", tt.in, got, err, tt.want, tt.valid)
+		}
 	}
 }
 

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -624,30 +624,82 @@ func main() {
 
 // addrBlobArg interprets a CLI destination argument as either a
 // "tc"-prefixed address blob or a DNS name whose "tailcat=" TXT
-// record holds one. A dot can never appear in a base64 address blob,
-// so anything containing one is treated as a DNS name; that also
-// keeps DNS names starting with "tc" working. It exits the process
-// on failure.
+// record holds one. It exits the process on failure.
 func addrBlobArg(arg string) tailcat.ConnBlob {
-	if strings.Contains(arg, ".") {
+	blob, dnsName, err := classifyAddrBlobArg(arg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if dnsName != "" {
 		var r net.Resolver
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		txts, err := r.LookupTXT(ctx, arg)
+		txts, err := r.LookupTXT(ctx, dnsName)
 		if err != nil {
-			log.Fatalf("looking up TXT record for %q: %v", arg, err)
+			log.Fatalf("looking up TXT record for %q: %v", dnsName, err)
 		}
 		for _, txt := range txts {
 			if suf, ok := strings.CutPrefix(txt, "tailcat="); ok {
 				return tailcat.ConnBlob(strings.TrimSpace(suf))
 			}
 		}
-		log.Fatalf("no \"tailcat=\" TXT record found for %q", arg)
+		log.Fatalf("no \"tailcat=\" TXT record found for %q", dnsName)
 	}
-	if !strings.HasPrefix(arg, "tc") {
-		log.Fatalf("argument %q is neither a \"tc\"-prefixed address blob nor a DNS name", arg)
+	return blob
+}
+
+// classifyAddrBlobArg classifies arg without performing a DNS lookup. It
+// rejects DNS-looking input containing a valid connection blob as a label so
+// that pasting a blob with an adjacent period or other dotted suffix cannot
+// disclose the blob in a DNS query.
+func classifyAddrBlobArg(arg string) (blob tailcat.ConnBlob, dnsName string, err error) {
+	blob = tailcat.ConnBlob(arg)
+	if _, err := tailcat.ParseConnBlob(blob); err == nil {
+		return blob, "", nil
 	}
-	return tailcat.ConnBlob(arg)
+	if !strings.Contains(arg, ".") {
+		return "", "", fmt.Errorf("argument %q is neither a valid connection blob nor a DNS name", arg)
+	}
+
+	name := strings.TrimSuffix(arg, ".")
+	for label := range strings.SplitSeq(name, ".") {
+		if _, err := tailcat.ParseConnBlob(tailcat.ConnBlob(label)); err == nil {
+			return "", "", errors.New("argument contains a valid connection blob as a DNS label; refusing DNS lookup")
+		}
+	}
+	if err := validateDNSName(name); err != nil {
+		return "", "", fmt.Errorf("invalid DNS name %q: %w", arg, err)
+	}
+	return "", arg, nil
+}
+
+// validateDNSName validates the conservative ASCII hostname syntax accepted
+// for connection-token TXT lookups.
+func validateDNSName(name string) error {
+	if name == "" {
+		return errors.New("name is empty")
+	}
+	if len(name) > 253 {
+		return errors.New("name is longer than 253 bytes")
+	}
+	for label := range strings.SplitSeq(name, ".") {
+		if label == "" {
+			return errors.New("name contains an empty label")
+		}
+		if len(label) > 63 {
+			return errors.New("name contains a label longer than 63 bytes")
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return errors.New("name contains a label beginning or ending with a hyphen")
+		}
+		for _, c := range []byte(label) {
+			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' {
+				continue
+			}
+			return fmt.Errorf("name contains invalid character %q", c)
+		}
+	}
+	return nil
 }
 
 func clientKey() key.NodePrivate {


### PR DESCRIPTION
If somebody tricks you into using an invalid tailcat address
(or perhaps via some automation/scripting), we shoudn't pass
it along blindly to child processes.

So far I'd just been using tailcat with myself, and I'm not in the
habit of tricking myself, but eventually tailcat will start to be used
between users and untrusted users and we should harden things for that
case too.

Thanks to Matt Andreko for the report!

Reported-by: Matt Andreko (https://www.mattandreko.com/)
