### PR TITLE
fix write-only shares to actually be write-only

### DIFF
--- a/tailcat_sftp.go
+++ b/tailcat_sftp.go
@@ -154,8 +154,21 @@ func (h *rootedFiles) Filewrite(r *sftp.Request) (io.WriterAt, error) {
 		return nil, sftp.ErrSSHFxPermissionDenied
 	}
 	pflags := r.Pflags()
-	if pflags.Read && h.mode == FileServeWO {
-		return nil, sftp.ErrSSHFxPermissionDenied
+	if h.mode == FileServeWO {
+		// A drop box only accepts creation of new files. Requiring the
+		// client to ask for creation makes a plain write-only open fail
+		// the same way whether its path exists or not; forcing exclusive
+		// creation makes the no-overwrite check atomic.
+		if pflags.Read || !pflags.Write || !pflags.Creat {
+			return nil, sftp.ErrSSHFxPermissionDenied
+		}
+		p := rel(r.Filepath)
+		f, err := h.root.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if err != nil {
+			return nil, err
+		}
+		h.markOwn(p)
+		return f, nil
 	}
 	flags := os.O_WRONLY
 	if pflags.Read && pflags.Write {
@@ -177,9 +190,6 @@ func (h *rootedFiles) Filewrite(r *sftp.Request) (io.WriterAt, error) {
 	f, err := h.root.OpenFile(p, flags, 0644)
 	if err != nil {
 		return nil, err
-	}
-	if h.mode == FileServeWO {
-		h.markOwn(p)
 	}
 	return f, nil
 }

--- a/tailcat_sftp_test.go
+++ b/tailcat_sftp_test.go
@@ -6,6 +6,7 @@
 package tailcat_test
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -161,6 +162,29 @@ func TestSFTPNoSymlinkEscape(t *testing.T) {
 func TestSFTPWriteOnly(t *testing.T) {
 	dir := newServeDir(t)
 	c := sftpClient(t, dir, tailcat.FileServeWO)
+
+	// A drop box may only create files. It must neither overwrite an
+	// existing file nor reveal its existence through a write-only open
+	// without O_CREATE.
+	if err := writeFile(c, "existing.txt", "overwritten"); err == nil {
+		t.Error("overwrite existing.txt succeeded in write-only mode")
+	}
+	if got, err := os.ReadFile(filepath.Join(dir, "existing.txt")); err != nil {
+		t.Fatalf("ReadFile existing.txt: %v", err)
+	} else if string(got) != "existing content" {
+		t.Errorf("existing.txt after overwrite attempt = %q; want %q", got, "existing content")
+	}
+	for _, name := range []string{"existing.txt", "absent.txt"} {
+		f, err := c.OpenFile(name, os.O_WRONLY)
+		if err == nil {
+			f.Close()
+			t.Errorf("write-only open without create of %s succeeded", name)
+			continue
+		}
+		if !errors.Is(err, os.ErrPermission) {
+			t.Errorf("write-only open without create of %s = %v; want permission denied", name, err)
+		}
+	}
 
 	if err := writeFile(c, "drop.txt", "dropped"); err != nil {
 		t.Fatalf("Create drop.txt: %v", err)


### PR DESCRIPTION
0.4.0 didn't do :wo (write-only) shares as documented (as done by
"tailcat recv"), permitting overwrite and file enumeration.

Fix both.

Thanks to Will Frame for the report!

Reported-by: Will Frame (https://wpf.nz/)
