### PR TITLE
deflake several tests under flakestress (oversubscription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ $ tailcat serve 8080,3306
 $ tailcat forward tcXXXXXXXXX 18080:8080 3306
 ```
 
+A local port of 0 asks the operating system for a free port; each listener prints its address once it's listening.
+
 By default, listeners bind to `127.0.0.1` and diagnostic logs are suppressed. Pass `--verbose` before the subcommand to enable verbose networking logs. Use `--bind=0.0.0.0` only when clients on other machines should be able to connect:
 
 ```sh

--- a/cmd/tailcat/forward.go
+++ b/cmd/tailcat/forward.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"os/signal"
@@ -29,10 +30,13 @@ func forwardCommand(parent *ff.FlagSet) *ff.Command {
 		LongHelp: `Listen on local TCP ports and forward connections to ports served by a tailcat server.
 
 A mapping with one port uses the same local and remote port. A mapping with
-local:remote uses different local and remote ports. For example:
+local:remote uses different local and remote ports. A local port of 0 asks
+the operating system for a free port; each listener prints its address once
+it's listening. For example:
 
 	tailcat forward <tc-addr> 8080
-	tailcat forward --bind=0.0.0.0 <tc-addr> 18080:8080`,
+	tailcat forward --bind=0.0.0.0 <tc-addr> 18080:8080
+	tailcat forward <tc-addr> 0:8080`,
 		Flags: fs,
 		Exec: func(ctx context.Context, args []string) error {
 			return runForward(ctx, getLogf(), *bind, args)
@@ -94,7 +98,10 @@ func runForward(ctx context.Context, logf logger.Logf, bind string, args []strin
 
 func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, ln net.Listener, remotePort uint16, listenersWG, connectionsWG *sync.WaitGroup, active *sync.Map) {
 	defer listenersWG.Done()
-	logf("forwarding %s -> remote localhost:%d", ln.Addr(), remotePort)
+	// Print unconditionally (not via the verbose-only logf): with a
+	// local port of 0 this line is the only way to learn which port
+	// the OS picked.
+	log.Printf("forwarding %s -> remote localhost:%d", ln.Addr(), remotePort)
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -127,9 +134,12 @@ func parseForwardSpec(bind, spec string) (string, uint16, error) {
 	if err != nil {
 		return "", 0, fmt.Errorf("remote port: %w", err)
 	}
-	localPort, err := parseForwardPort(local)
-	if err != nil {
-		return "", 0, fmt.Errorf("local port: %w", err)
+	var localPort uint16
+	if !hasColon || local != "0" { // local port 0 asks the OS for a free port
+		localPort, err = parseForwardPort(local)
+		if err != nil {
+			return "", 0, fmt.Errorf("local port: %w", err)
+		}
 	}
 	return net.JoinHostPort(bind, strconv.Itoa(int(localPort))), remotePort, nil
 }

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -6,6 +6,9 @@ package main
 import (
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -21,6 +24,7 @@ func TestParseForwardSpec(t *testing.T) {
 		{"18080:8080", "127.0.0.1:18080", 8080, false},
 		{"1:65535", "127.0.0.1:1", 65535, false},
 		{"0", "", 0, true},
+		{"0:8080", "127.0.0.1:0", 8080, false},
 		{"8080:0", "", 0, true},
 		{"8080:bad", "", 0, true},
 	} {
@@ -42,15 +46,23 @@ func TestParseForwardSpec(t *testing.T) {
 func TestForwardEndToEnd(t *testing.T) {
 	e := newTestEnv(t)
 	remotePort := startEchoListener(t)
-	localLn, err := net.Listen("tcp", "127.0.0.1:0")
+
+	_, tailcatAddr, serverStderr := e.startServer("--verbose", "serve", strconv.Itoa(int(remotePort)))
+
+	// Forward from local port 0 (OS-assigned) and learn the picked
+	// address from the "forwarding" line on stderr. Pre-picking a free
+	// port here and passing it explicitly would race other processes
+	// on this machine binding it first. Stderr goes to a file, polled
+	// below, because reading a shared buffer while the process writes
+	// it would race.
+	forward := e.cmd("--verbose", "--key=new", "--derpmap-url="+e.derpMapURL, "forward", tailcatAddr, fmt.Sprintf("0:%d", remotePort))
+	stderrPath := filepath.Join(t.TempDir(), "forward.stderr")
+	stderrFile, err := os.Create(stderrPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	localPort := localLn.Addr().(*net.TCPAddr).Port
-	localLn.Close()
-
-	_, tailcatAddr, _ := e.startServer("serve", strconv.Itoa(int(remotePort)))
-	forward := e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, "forward", tailcatAddr, fmt.Sprintf("%d:%d", localPort, remotePort))
+	defer stderrFile.Close()
+	forward.Stderr = stderrFile
 	if err := forward.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -58,19 +70,29 @@ func TestForwardEndToEnd(t *testing.T) {
 		_ = forward.Process.Kill()
 		_ = forward.Wait()
 	})
+	forwardStderr := func() string {
+		b, _ := os.ReadFile(stderrPath)
+		return string(b)
+	}
 
-	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort))
-	var conn net.Conn
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
-		if err == nil {
+	addrRx := regexp.MustCompile(`forwarding (\S+) ->`)
+	var addr string
+	deadline := time.Now().Add(30 * time.Second)
+	for addr == "" {
+		if time.Now().After(deadline) {
+			t.Fatalf("forward never listened; stderr:\n%s", forwardStderr())
+		}
+		if m := addrRx.FindStringSubmatch(forwardStderr()); m != nil {
+			addr = m[1]
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+	t.Logf("forwarding from %s", addr)
+
+	conn, err := net.Dial("tcp", addr)
 	if err != nil {
-		t.Fatalf("forward listener did not become available: %v", err)
+		t.Fatal(err)
 	}
 	defer conn.Close()
 
@@ -80,7 +102,7 @@ func TestForwardEndToEnd(t *testing.T) {
 	}
 	got := make([]byte, len(payload))
 	if _, err := conn.Read(got); err != nil {
-		t.Fatal(err)
+		t.Fatalf("read: %v\nforward stderr:\n%s\nserver stderr:\n%s", err, forwardStderr(), serverStderr)
 	}
 	if string(got) != payload {
 		t.Errorf("got %q; want %q", got, payload)

--- a/cmd/tailcat/serve_test.go
+++ b/cmd/tailcat/serve_test.go
@@ -43,8 +43,13 @@ func startEchoListener(t *testing.T) uint16 {
 }
 
 // runClient runs an unstarted tailcat client command with payload on
-// its stdin and a 30 second watchdog, returning its stdout and error.
-func runClient(t *testing.T, client *exec.Cmd, payload string) (string, error) {
+// its stdin and a 60 second watchdog, returning its stdout and error.
+// The watchdog only exists to catch true hangs; it's generous because
+// a loaded machine can drop relayed packets and leave the transfer
+// waiting out TCP retransmit backoff. On failure, the error includes
+// the client's stderr and the given server stderr (which may be nil),
+// so both sides of a wedged conversation are visible.
+func runClient(t *testing.T, client *exec.Cmd, serverStderr *bytes.Buffer, payload string) (string, error) {
 	t.Helper()
 	client.Stdin = strings.NewReader(payload)
 	var stdout, stderr bytes.Buffer
@@ -53,17 +58,24 @@ func runClient(t *testing.T, client *exec.Cmd, payload string) (string, error) {
 	if err := client.Start(); err != nil {
 		t.Fatal(err)
 	}
+	bothStderrs := func() string {
+		s := fmt.Sprintf("client stderr:\n%s", stderr.String())
+		if serverStderr != nil {
+			s += fmt.Sprintf("\nserver stderr:\n%s", serverStderr.String())
+		}
+		return s
+	}
 	done := make(chan error, 1)
 	go func() { done <- client.Wait() }()
 	select {
 	case err := <-done:
 		if err != nil {
-			err = fmt.Errorf("%w\nclient stderr:\n%s", err, stderr.String())
+			err = fmt.Errorf("%w\n%s", err, bothStderrs())
 		}
 		return stdout.String(), err
-	case <-time.After(30 * time.Second):
+	case <-time.After(60 * time.Second):
 		client.Process.Kill()
-		t.Fatalf("client did not exit within 30s\nclient stderr:\n%s", stderr.String())
+		t.Fatalf("client did not exit within 60s\n%s", bothStderrs())
 		panic("unreachable")
 	}
 }
@@ -84,10 +96,10 @@ func TestServePorts(t *testing.T) {
 	unservedPort := ln.Addr().(*net.TCPAddr).Port
 	ln.Close()
 
-	_, addr, _ := e.startServer("serve", strconv.Itoa(int(port)))
+	_, addr, serverStderr := e.startServer("--verbose", "serve", strconv.Itoa(int(port)))
 
 	const payload = "echo through a served port"
-	got, err := runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port))), payload)
+	got, err := runClient(t, e.cmd("--verbose", "--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port))), serverStderr, payload)
 	if err != nil {
 		t.Fatalf("client to served port: %v", err)
 	}
@@ -95,7 +107,7 @@ func TestServePorts(t *testing.T) {
 		t.Errorf("served port echoed %q; want %q", got, payload)
 	}
 
-	got, err = runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(unservedPort)), payload)
+	got, err = runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(unservedPort)), serverStderr, payload)
 	if err == nil {
 		t.Errorf("client to unserved port %v succeeded with output %q; want connection failure", unservedPort, got)
 	}
@@ -110,11 +122,11 @@ func TestServeExitNode(t *testing.T) {
 	port := startEchoListener(t)
 	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), port)
 
-	_, addr, _ := e.startServer("--serve=exit-node")
+	_, addr, serverStderr := e.startServer("--verbose", "--serve=exit-node")
 
 	t.Run("client_ipport", func(t *testing.T) {
 		const payload = "echo through the exit node"
-		got, err := runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, dst.String()), payload)
+		got, err := runClient(t, e.cmd("--verbose", "--key=new", "--derpmap-url="+e.derpMapURL, addr, dst.String()), serverStderr, payload)
 		if err != nil {
 			t.Fatalf("client to %v: %v", dst, err)
 		}

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -989,6 +989,13 @@ func clientSOCKSMode(logf logger.Logf, listen string, args []string) error {
 	ss := &socks5.Server{
 		Logf: logger.WithPrefix(logf, "socks5: "),
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// The socks5 package caps each dial at 5 seconds, which
+			// is also WireGuard's handshake retransmit interval, so
+			// a single lost handshake packet would push the dial
+			// past that budget and fail the CONNECT. Detach from the
+			// package's deadline and use a more generous one.
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+			defer cancel()
 			dst, err := classifySOCKSAddr(ctx, lookupNetIP, addr)
 			if err != nil {
 				return nil, err

--- a/tailcat.go
+++ b/tailcat.go
@@ -1744,9 +1744,10 @@ func (c *Client) up(ctx context.Context) error {
 }
 
 // Ping starts the client if needed (see [Client.Dial] for the lazy
-// startup behavior), sends a meow ping to the server via DERP, and
-// waits for the meowed acknowledgment, which also tells the server
-// to add us as a WireGuard peer. Calling it is optional (Dial does
+// startup behavior), sends a meow ping to the server via DERP
+// (resending periodically in case of packet loss), and waits for the
+// meowed acknowledgment, which also tells the server to add us as a
+// WireGuard peer. Calling it is optional (Dial does
 // it implicitly) but useful to test connectivity or measure the
 // relay round-trip time. The internal timeout is 10 seconds
 // regardless of ctx.
@@ -1762,8 +1763,8 @@ func (c *Client) Ping(ctx context.Context) (PingResult, error) {
 	return res, err
 }
 
-// ping sends a single meow ping and waits for the meowed ack. The
-// client must be started.
+// ping sends a meow ping and waits for the meowed ack. The client
+// must be started.
 func (c *Client) ping(ctx context.Context) (PingResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -1776,19 +1777,39 @@ func (c *Client) ping(ctx context.Context) (PingResult, error) {
 	derpRegion := c.lb.derpRegionID()
 	pkt := EncodeMeowPing(c.lb.pub, mc.DiscoPublicKey())
 
-	sent, err := mc.SendDERPPacketTo(dstNode, derpRegion, pkt)
-	if err != nil {
-		return zero, fmt.Errorf("sending meow: %w", err)
+	// DERP delivery is best effort: the relay drops packets sent to a
+	// key that isn't connected yet, so the ping (or its ack) is lost
+	// if either side's relay connection is still coming up. Resend
+	// periodically rather than betting the whole timeout on one
+	// packet. Send failures are retryable for the same reason: a full
+	// relay write queue drops the packet, which is just packet loss
+	// happening early. The server acks every ping, so duplicates are
+	// harmless.
+	send := func() error {
+		sent, err := mc.SendDERPPacketTo(dstNode, derpRegion, pkt)
+		if err != nil {
+			return fmt.Errorf("sending meow: %w", err)
+		}
+		if !sent {
+			return errors.New("meow not sent")
+		}
+		return nil
 	}
-	if !sent {
-		return zero, fmt.Errorf("meow not sent")
-	}
-
-	select {
-	case <-c.meowWait:
-		return PingResult{time.Since(t0)}, nil
-	case <-ctx.Done():
-		return zero, ctx.Err()
+	lastSendErr := send()
+	resend := time.NewTicker(time.Second)
+	defer resend.Stop()
+	for {
+		select {
+		case <-c.meowWait:
+			return PingResult{time.Since(t0)}, nil
+		case <-ctx.Done():
+			if lastSendErr != nil {
+				return zero, fmt.Errorf("%w (last send error: %v)", ctx.Err(), lastSendErr)
+			}
+			return zero, ctx.Err()
+		case <-resend.C:
+			lastSendErr = send()
+		}
 	}
 }
 


### PR DESCRIPTION
- **tailcat: resend meow pings instead of betting the timeout on one packet**
- **cmd/tailcat: give SOCKS dials a longer budget than one WireGuard handshake**
- **cmd/tailcat: let forward pick a free local port with 0**
- **cmd/tailcat: improve serve test diagnostics, widen client watchdog**
