### PR TITLE
cmd/tailcat: support forwarding to exit-node targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ HTTP/1.1 200 OK
 ....
 ```
 
+### Forward local ports to a tailcat server
+
+To make ports served by a tailcat server available as ordinary local TCP ports (for browsers, database clients, or other tools that do not support SOCKS or stdio), run `forward` with the server's address token:
+
+```sh
+$ tailcat serve 8080,3306
+# 🐈 Server listening with new address: tcXXXXXXXXX
+
+$ tailcat forward tcXXXXXXXXX 18080:8080 3306
+```
+
+By default, listeners bind to `127.0.0.1` and diagnostic logs are suppressed. Pass `--verbose` before the subcommand to enable verbose networking logs. Use `--bind=0.0.0.0` only when clients on other machines should be able to connect:
+
+```sh
+$ tailcat forward --bind=0.0.0.0 tcXXXXXXXXX 18080:8080
+```
+
+Press Ctrl-C to stop forwarding.
+
 ### Auth-free SSH server
 
 On Linux and macOS, you can run an SSH server too with no auth. (If you want auth, you can just `tailcat serve 22` and proxy to your system SSH server)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ $ tailcat serve 8080,3306
 $ tailcat forward tcXXXXXXXXX 18080:8080 3306
 ```
 
+To forward local ports to assets on the network reachable by an exit-node server, run the server in exit-node mode and specify each remote IP address and port in the mapping:
+
+```sh
+$ tailcat serve exit-node
+# 🐈 Server listening with new address: tcXXXXXXXXX
+
+$ tailcat forward tcXXXXXXXXX \\
+    3001:172.23.52.30:3001 \\
+    17170:172.23.52.31:17170
+```
+
+This forwards `127.0.0.1:3001` to `172.23.52.30:3001` and `127.0.0.1:17170` to `172.23.52.31:17170` through the exit-node server.
+
 By default, listeners bind to `127.0.0.1` and diagnostic logs are suppressed. Pass `--verbose` before the subcommand to enable verbose networking logs. Use `--bind=0.0.0.0` only when clients on other machines should be able to connect:
 
 ```sh

--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -21,7 +21,7 @@ func TestHelpListsCommandTree(t *testing.T) {
 	help := ffhelp.Command(newRootCommand()).String()
 	for _, want := range []string{
 		"serve", "recv", "ping", "socks", "ssh", "cp", "parse", "resolve",
-		"genkey", "printpub", "version", "readme",
+		"forward", "genkey", "printpub", "version", "readme",
 		"--serve", "--key", "--derpmap-url",
 	} {
 		if !strings.Contains(help, want) {
@@ -273,6 +273,27 @@ func TestGenkeyRequiresKeyName(t *testing.T) {
 	err = root.Run(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "--key=client-default") {
 		t.Errorf("genkey --client --key=default: err = %v; want one suggesting --key=client-default", err)
+	}
+}
+
+// TestForwardSubcommand verifies that forward parses its bind flag and
+// positional address blob and mappings without executing the listener.
+func TestForwardSubcommand(t *testing.T) {
+	root, err := parseCLI(t, "forward", "--bind=0.0.0.0", "tcblob", "18080:8080", "9090")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sel := root.GetSelected()
+	if sel.Name != "forward" {
+		t.Fatalf("selected command = %q; want forward", sel.Name)
+	}
+	got := sel.Flags.(*ff.FlagSet).GetArgs()
+	want := []string{"tcblob", "18080:8080", "9090"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("leftover args = %q; want %q", got, want)
+	}
+	if f, ok := sel.Flags.GetFlag("bind"); !ok || f.GetValue() != "0.0.0.0" {
+		t.Errorf("--bind = %v; want 0.0.0.0", f)
 	}
 }
 

--- a/cmd/tailcat/forward.go
+++ b/cmd/tailcat/forward.go
@@ -1,0 +1,143 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/peterbourgon/ff/v4"
+	"github.com/tailscale/tailcat"
+	"tailscale.com/types/logger"
+)
+
+func forwardCommand(parent *ff.FlagSet) *ff.Command {
+	fs := ff.NewFlagSet("forward").SetParent(parent)
+	bind := fs.StringLong("bind", "127.0.0.1", "listen address; used as the local address when a mapping only specifies a port")
+	return &ff.Command{
+		Name:      "forward",
+		Usage:     "tailcat forward [flags] <addrblob> <[local:]remote> [<[local:]remote> ...]",
+		ShortHelp: "forward local TCP ports to a tailcat server",
+		LongHelp: `Listen on local TCP ports and forward connections to ports served by a tailcat server.
+
+A mapping with one port uses the same local and remote port. A mapping with
+local:remote uses different local and remote ports. For example:
+
+	tailcat forward <addrblob> 8080
+	tailcat forward --bind=0.0.0.0 <addrblob> 18080:8080`,
+		Flags: fs,
+		Exec: func(ctx context.Context, args []string) error {
+			return runForward(ctx, getLogf(), *bind, args)
+		},
+	}
+}
+
+func runForward(ctx context.Context, logf logger.Logf, bind string, args []string) error {
+	if len(args) < 2 {
+		return usagef("forward takes an <addrblob> and at least one port mapping")
+	}
+
+	cl := newClient(logf, addrBlobArg(args[0]), clientKey())
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	listeners := make([]net.Listener, 0, len(args)-1)
+	var listenersWG, connectionsWG sync.WaitGroup
+	var active sync.Map
+	defer func() {
+		stop()
+		for _, ln := range listeners {
+			_ = ln.Close()
+		}
+		listenersWG.Wait()
+		active.Range(func(key, _ any) bool {
+			_ = key.(net.Conn).Close()
+			return true
+		})
+		connectionsWG.Wait()
+		_ = cl.Close()
+	}()
+	for _, spec := range args[1:] {
+		listenAddr, remotePort, err := parseForwardSpec(bind, spec)
+		if err != nil {
+			for _, ln := range listeners {
+				ln.Close()
+			}
+			return usagef("mapping %q is invalid: %v", spec, err)
+		}
+		ln, err := net.Listen("tcp", listenAddr)
+		if err != nil {
+			for _, old := range listeners {
+				old.Close()
+			}
+			return fmt.Errorf("listen on %s: %w", listenAddr, err)
+		}
+		listeners = append(listeners, ln)
+		listenersWG.Add(1)
+		go forwardListener(ctx, logf, cl, ln, remotePort, &listenersWG, &connectionsWG, &active)
+	}
+
+	<-ctx.Done()
+	for _, ln := range listeners {
+		ln.Close()
+	}
+	return nil
+}
+
+func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, ln net.Listener, remotePort uint16, listenersWG, connectionsWG *sync.WaitGroup, active *sync.Map) {
+	defer listenersWG.Done()
+	logf("forwarding %s -> remote localhost:%d", ln.Addr(), remotePort)
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		connectionsWG.Add(1)
+		active.Store(conn, struct{}{})
+		go func() {
+			defer connectionsWG.Done()
+			defer active.Delete(conn)
+			defer conn.Close()
+			remote, err := cl.DialTCPPort(ctx, remotePort)
+			if err != nil {
+				if ctx.Err() == nil {
+					logf("dial remote port %d: %v", remotePort, err)
+				}
+				return
+			}
+			tailcat.ProxyConns(conn, remote)
+		}()
+	}
+}
+
+func parseForwardSpec(bind, spec string) (string, uint16, error) {
+	local, remote, hasColon := strings.Cut(spec, ":")
+	if !hasColon {
+		remote = local
+	}
+	remotePort, err := parseForwardPort(remote)
+	if err != nil {
+		return "", 0, fmt.Errorf("remote port: %w", err)
+	}
+	localPort, err := parseForwardPort(local)
+	if err != nil {
+		return "", 0, fmt.Errorf("local port: %w", err)
+	}
+	return net.JoinHostPort(bind, strconv.Itoa(int(localPort))), remotePort, nil
+}
+
+func parseForwardPort(s string) (uint16, error) {
+	p, err := strconv.ParseUint(s, 10, 16)
+	if err != nil || p == 0 {
+		return 0, fmt.Errorf("invalid port %q", s)
+	}
+	return uint16(p), nil
+}

--- a/cmd/tailcat/forward.go
+++ b/cmd/tailcat/forward.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/signal"
 	"strconv"
@@ -24,20 +25,36 @@ func forwardCommand(parent *ff.FlagSet) *ff.Command {
 	bind := fs.StringLong("bind", "127.0.0.1", "listen address; used as the local address when a mapping only specifies a port")
 	return &ff.Command{
 		Name:      "forward",
-		Usage:     "tailcat forward [flags] <addrblob> <[local:]remote> [<[local:]remote> ...]",
+		Usage:     "tailcat forward [flags] <addrblob> <[local:]remote-port|local-port:remote-host:remote-port> [<...> ...]",
 		ShortHelp: "forward local TCP ports to a tailcat server",
-		LongHelp: `Listen on local TCP ports and forward connections to ports served by a tailcat server.
+		LongHelp: `Listen on local TCP ports and forward connections to a tailcat server.
 
 A mapping with one port uses the same local and remote port. A mapping with
-local:remote uses different local and remote ports. For example:
+local:remote uses different local and remote ports. A mapping with a remote
+host and port requires the server to be running as an exit node. For example:
 
 	tailcat forward <addrblob> 8080
+	tailcat forward <addrblob> 3000:8080
+	tailcat forward <addrblob> 13306:192.168.1.10:3306
 	tailcat forward --bind=0.0.0.0 <addrblob> 18080:8080`,
 		Flags: fs,
 		Exec: func(ctx context.Context, args []string) error {
 			return runForward(ctx, getLogf(), *bind, args)
 		},
 	}
+}
+
+type forwardSpec struct {
+	listenAddr string
+	target     netip.AddrPort
+	port       uint16
+}
+
+func (s forwardSpec) remoteTarget() string {
+	if s.target.IsValid() {
+		return s.target.String()
+	}
+	return net.JoinHostPort("localhost", strconv.Itoa(int(s.port)))
 }
 
 func runForward(ctx context.Context, logf logger.Logf, bind string, args []string) error {
@@ -66,23 +83,23 @@ func runForward(ctx context.Context, logf logger.Logf, bind string, args []strin
 		_ = cl.Close()
 	}()
 	for _, spec := range args[1:] {
-		listenAddr, remotePort, err := parseForwardSpec(bind, spec)
+		mapping, err := parseForwardSpec(bind, spec)
 		if err != nil {
 			for _, ln := range listeners {
 				ln.Close()
 			}
 			return usagef("mapping %q is invalid: %v", spec, err)
 		}
-		ln, err := net.Listen("tcp", listenAddr)
+		ln, err := net.Listen("tcp", mapping.listenAddr)
 		if err != nil {
 			for _, old := range listeners {
 				old.Close()
 			}
-			return fmt.Errorf("listen on %s: %w", listenAddr, err)
+			return fmt.Errorf("listen on %s: %w", mapping.listenAddr, err)
 		}
 		listeners = append(listeners, ln)
 		listenersWG.Add(1)
-		go forwardListener(ctx, logf, cl, ln, remotePort, &listenersWG, &connectionsWG, &active)
+		go forwardListener(ctx, logf, cl, ln, mapping, &listenersWG, &connectionsWG, &active)
 	}
 
 	<-ctx.Done()
@@ -92,9 +109,9 @@ func runForward(ctx context.Context, logf logger.Logf, bind string, args []strin
 	return nil
 }
 
-func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, ln net.Listener, remotePort uint16, listenersWG, connectionsWG *sync.WaitGroup, active *sync.Map) {
+func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, ln net.Listener, mapping forwardSpec, listenersWG, connectionsWG *sync.WaitGroup, active *sync.Map) {
 	defer listenersWG.Done()
-	logf("forwarding %s -> remote localhost:%d", ln.Addr(), remotePort)
+	logf("forwarding %s -> remote %s", ln.Addr(), mapping.remoteTarget())
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -106,10 +123,16 @@ func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, 
 			defer connectionsWG.Done()
 			defer active.Delete(conn)
 			defer conn.Close()
-			remote, err := cl.DialTCPPort(ctx, remotePort)
+			var remote net.Conn
+			var err error
+			if mapping.target.IsValid() {
+				remote, err = cl.DialTCP(ctx, mapping.target)
+			} else {
+				remote, err = cl.DialTCPPort(ctx, mapping.port)
+			}
 			if err != nil {
 				if ctx.Err() == nil {
-					logf("dial remote port %d: %v", remotePort, err)
+					logf("dial remote target %s: %v", mapping.remoteTarget(), err)
 				}
 				return
 			}
@@ -118,20 +141,34 @@ func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, 
 	}
 }
 
-func parseForwardSpec(bind, spec string) (string, uint16, error) {
-	local, remote, hasColon := strings.Cut(spec, ":")
+func parseForwardSpec(bind, spec string) (forwardSpec, error) {
+	local, target, hasColon := strings.Cut(spec, ":")
 	if !hasColon {
-		remote = local
-	}
-	remotePort, err := parseForwardPort(remote)
-	if err != nil {
-		return "", 0, fmt.Errorf("remote port: %w", err)
+		target = local
 	}
 	localPort, err := parseForwardPort(local)
 	if err != nil {
-		return "", 0, fmt.Errorf("local port: %w", err)
+		return forwardSpec{}, fmt.Errorf("local port: %w", err)
 	}
-	return net.JoinHostPort(bind, strconv.Itoa(int(localPort))), remotePort, nil
+	mapping := forwardSpec{listenAddr: net.JoinHostPort(bind, strconv.Itoa(int(localPort)))}
+	if !hasColon {
+		mapping.port, err = parseForwardPort(target)
+		if err != nil {
+			return forwardSpec{}, fmt.Errorf("remote port: %w", err)
+		}
+		return mapping, nil
+	}
+	remotePort, err := parseForwardPort(target)
+	if err == nil {
+		mapping.port = remotePort
+		return mapping, nil
+	}
+	remoteAddr, err := netip.ParseAddrPort(target)
+	if err != nil {
+		return forwardSpec{}, fmt.Errorf("remote target %q is not a port or address:port", target)
+	}
+	mapping.target = remoteAddr
+	return mapping, nil
 }
 
 func parseForwardPort(s string) (uint16, error) {

--- a/cmd/tailcat/forward.go
+++ b/cmd/tailcat/forward.go
@@ -25,13 +25,14 @@ func forwardCommand(parent *ff.FlagSet) *ff.Command {
 	bind := fs.StringLong("bind", "127.0.0.1", "listen address; used as the local address when a mapping only specifies a port")
 	return &ff.Command{
 		Name:      "forward",
-		Usage:     "tailcat forward [flags] <addrblob> <[local:]remote-port|local-port:remote-host:remote-port> [<...> ...]",
+		Usage:     "tailcat forward [flags] <addrblob> <[local:]remote-port|local-port:remote-ip:remote-port> [<...> ...]",
 		ShortHelp: "forward local TCP ports to a tailcat server",
 		LongHelp: `Listen on local TCP ports and forward connections to a tailcat server.
 
 A mapping with one port uses the same local and remote port. A mapping with
 local:remote uses different local and remote ports. A mapping with a remote
-host and port requires the server to be running as an exit node. For example:
+IP address and port requires the server to be running as an exit node. For
+example:
 
 	tailcat forward <addrblob> 8080
 	tailcat forward <addrblob> 3000:8080

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -15,25 +15,28 @@ func TestParseForwardSpec(t *testing.T) {
 	for _, tt := range []struct {
 		spec, wantAddr string
 		wantPort       uint16
+		wantTarget     string
 		wantErr        bool
 	}{
-		{"8080", "127.0.0.1:8080", 8080, false},
-		{"18080:8080", "127.0.0.1:18080", 8080, false},
-		{"1:65535", "127.0.0.1:1", 65535, false},
-		{"0", "", 0, true},
-		{"8080:0", "", 0, true},
-		{"8080:bad", "", 0, true},
+		{"8080", "127.0.0.1:8080", 8080, "", false},
+		{"18080:8080", "127.0.0.1:18080", 8080, "", false},
+		{"13306:192.168.1.10:3306", "127.0.0.1:13306", 0, "192.168.1.10:3306", false},
+		{"13306:[2001:db8::10]:3306", "127.0.0.1:13306", 0, "[2001:db8::10]:3306", false},
+		{"0", "", 0, "", true},
+		{"8080:0", "", 0, "", true},
+		{"8080:bad", "", 0, "", true},
+		{"8080:192.168.1.10:bad", "", 0, "", true},
 	} {
 		t.Run(tt.spec, func(t *testing.T) {
-			gotAddr, gotPort, err := parseForwardSpec("127.0.0.1", tt.spec)
+			got, err := parseForwardSpec("127.0.0.1", tt.spec)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("parseForwardSpec succeeded; want error")
 				}
 				return
 			}
-			if err != nil || gotAddr != tt.wantAddr || gotPort != tt.wantPort {
-				t.Fatalf("parseForwardSpec(%q) = %q, %d, %v; want %q, %d", tt.spec, gotAddr, gotPort, err, tt.wantAddr, tt.wantPort)
+			if err != nil || got.listenAddr != tt.wantAddr || got.port != tt.wantPort || got.target.String() != tt.wantTarget {
+				t.Fatalf("parseForwardSpec(%q) = %#v, %v; want address %q, port %d, target %q", tt.spec, got, err, tt.wantAddr, tt.wantPort, tt.wantTarget)
 			}
 		})
 	}

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"testing"
 	"time"
@@ -42,6 +43,55 @@ func TestParseForwardSpec(t *testing.T) {
 	}
 }
 
+func TestForwardToExitNodeTarget(t *testing.T) {
+	e := newTestEnv(t)
+	remotePort := startEchoListener(t)
+	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), remotePort)
+	localLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	localPort := localLn.Addr().(*net.TCPAddr).Port
+	localLn.Close()
+
+	_, blob, _ := e.startServer("--serve=exit-node")
+	forward := e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, "forward", blob, fmt.Sprintf("%d:%s", localPort, dst))
+	if err := forward.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = forward.Process.Kill()
+		_ = forward.Wait()
+	})
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(localPort)))
+	var conn net.Conn
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("forward listener did not become available: %v", err)
+	}
+	defer conn.Close()
+
+	const payload = "forwarded to an exit-node target"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := conn.Read(got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payload {
+		t.Errorf("got %q; want %q", got, payload)
+	}
+}
+
 func TestForwardEndToEnd(t *testing.T) {
 	e := newTestEnv(t)
 	remotePort := startEchoListener(t)
@@ -62,7 +112,7 @@ func TestForwardEndToEnd(t *testing.T) {
 		_ = forward.Wait()
 	})
 
-	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort))
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(localPort)))
 	var conn net.Conn
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestParseForwardSpec(t *testing.T) {
+	for _, tt := range []struct {
+		spec, wantAddr string
+		wantPort       uint16
+		wantErr        bool
+	}{
+		{"8080", "127.0.0.1:8080", 8080, false},
+		{"18080:8080", "127.0.0.1:18080", 8080, false},
+		{"1:65535", "127.0.0.1:1", 65535, false},
+		{"0", "", 0, true},
+		{"8080:0", "", 0, true},
+		{"8080:bad", "", 0, true},
+	} {
+		t.Run(tt.spec, func(t *testing.T) {
+			gotAddr, gotPort, err := parseForwardSpec("127.0.0.1", tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseForwardSpec succeeded; want error")
+				}
+				return
+			}
+			if err != nil || gotAddr != tt.wantAddr || gotPort != tt.wantPort {
+				t.Fatalf("parseForwardSpec(%q) = %q, %d, %v; want %q, %d", tt.spec, gotAddr, gotPort, err, tt.wantAddr, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestForwardEndToEnd(t *testing.T) {
+	e := newTestEnv(t)
+	remotePort := startEchoListener(t)
+	localLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	localPort := localLn.Addr().(*net.TCPAddr).Port
+	localLn.Close()
+
+	_, blob, _ := e.startServer("serve", strconv.Itoa(int(remotePort)))
+	forward := e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, "forward", blob, fmt.Sprintf("%d:%d", localPort, remotePort))
+	if err := forward.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = forward.Process.Kill()
+		_ = forward.Wait()
+	})
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort))
+	var conn net.Conn
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("forward listener did not become available: %v", err)
+	}
+	defer conn.Close()
+
+	const payload = "forwarded over tailcat"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := conn.Read(got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payload {
+		t.Errorf("got %q; want %q", got, payload)
+	}
+}

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -190,6 +190,7 @@ func newRootCommand() *ff.Command {
 			sshCommand(rootFS),
 			cpCommand(rootFS),
 			lsCommand(rootFS),
+			forwardCommand(rootFS),
 			{
 				Name:      "parse",
 				Usage:     "tailcat parse <addrblob>",
@@ -332,6 +333,10 @@ and serve's files service):
 Client mode, list the files a server offers:
 
 	tailcat ls [-l] <addrblob>[:path]
+
+Client mode, forward local TCP ports to a tailcat server:
+
+	tailcat forward [--bind=<addr>] <addrblob> <[local:]remote> ...
 
 Client mode, run an ephemeral SOCKS5 proxy and pass its address
 as 'all_proxy' environment variable to a child process. Destination


### PR DESCRIPTION
## What does this change do?

Extend `tailcat forward` to expose arbitrary IP:port targets reachable through a Tailnet server running as an exit node.

This makes it possible to forward local TCP ports to assets on the exit node's network, including multiple targets in one command, without requiring SOCKS or application-specific proxy support.

Related to #14.

## Examples

Start an exit-node server:

```sh
tailcat serve exit-node
# Server listening with new address: tcXXXXXXXXX
```

Forward local ports to two remote targets:

```sh
tailcat forward tcXXXXXXXXX \
    3001:172.23.52.30:3001 \
    17170:172.23.52.31:17170
```

This forwards:

```text
127.0.0.1:3001  -> 172.23.52.30:3001
127.0.0.1:17170 -> 172.23.52.31:17170
```

## Design

- Keeps existing local-to-server port forwarding behavior.
- Supports local-port to remote IP:port mappings for exit-node targets.
- Supports multiple mappings in one `tailcat forward` invocation.
- Uses the existing `Client.DialTCP` and `ProxyConns` APIs.
- Does not change the Tailnet wire protocol.
- Does not introduce a new dependency.

## Testing

- Added parsing coverage for IP:port exit-node targets.
- Added an end-to-end test for forwarding to an exit-node target.
- Preserved the existing end-to-end test for ordinary served-port forwarding.

Tested with:

```sh
go test ./cmd/tailcat -run '^TestForward(ToExitNodeTarget|EndToEnd)$' -v
```