### PR TITLE
cmd/tailcat: support forwarding to exit-node targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ $ tailcat forward tcXXXXXXXXX 18080:8080 3306
 
 A local port of 0 asks the operating system for a free port; each listener prints its address once it's listening.
 
+To forward local ports to assets on the network reachable by an exit-node server, run the server in exit-node mode and specify each remote IP address and port in the mapping:
+
+```sh
+$ tailcat serve exit-node
+# 🐈 Server listening with new address: tcXXXXXXXXX
+
+$ tailcat forward tcXXXXXXXXX \\
+    3001:172.23.52.30:3001 \\
+    17170:172.23.52.31:17170
+```
+
+This forwards `127.0.0.1:3001` to `172.23.52.30:3001` and `127.0.0.1:17170` to `172.23.52.31:17170` through the exit-node server.
+
 By default, listeners bind to `127.0.0.1` and diagnostic logs are suppressed. Pass `--verbose` before the subcommand to enable verbose networking logs. Use `--bind=0.0.0.0` only when clients on other machines should be able to connect:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ To forward local ports to assets on the network reachable by an exit-node server
 $ tailcat serve exit-node
 # 🐈 Server listening with new address: tcXXXXXXXXX
 
-$ tailcat forward tcXXXXXXXXX \\
-    3001:172.23.52.30:3001 \\
+$ tailcat forward tcXXXXXXXXX \
+    3001:172.23.52.30:3001 \
     17170:172.23.52.31:17170
 ```
 

--- a/cmd/tailcat/forward.go
+++ b/cmd/tailcat/forward.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"os/signal"
 	"strconv"
@@ -25,23 +26,38 @@ func forwardCommand(parent *ff.FlagSet) *ff.Command {
 	bind := fs.StringLong("bind", "127.0.0.1", "listen address; used as the local address when a mapping only specifies a port")
 	return &ff.Command{
 		Name:      "forward",
-		Usage:     "tailcat forward [flags] <tc-addr> <[local:]remote> [<[local:]remote> ...]",
+		Usage:     "tailcat forward [flags] <tc-addr> <[local:]remote-port|local-port:remote-ip:remote-port> [<...> ...]",
 		ShortHelp: "forward local TCP ports to a tailcat server",
-		LongHelp: `Listen on local TCP ports and forward connections to ports served by a tailcat server.
+		LongHelp: `Listen on local TCP ports and forward connections to a tailcat server.
 
 A mapping with one port uses the same local and remote port. A mapping with
 local:remote uses different local and remote ports. A local port of 0 asks
 the operating system for a free port; each listener prints its address once
-it's listening. For example:
+it's listening. A mapping with a remote IP address and port requires the
+server to be running as an exit node. For example:
 
 	tailcat forward <tc-addr> 8080
 	tailcat forward --bind=0.0.0.0 <tc-addr> 18080:8080
-	tailcat forward <tc-addr> 0:8080`,
+	tailcat forward <tc-addr> 0:8080
+	tailcat forward <tc-addr> 13306:192.168.1.10:3306`,
 		Flags: fs,
 		Exec: func(ctx context.Context, args []string) error {
 			return runForward(ctx, getLogf(), *bind, args)
 		},
 	}
+}
+
+type forwardSpec struct {
+	listenAddr string
+	target     netip.AddrPort
+	port       uint16
+}
+
+func (s forwardSpec) remoteTarget() string {
+	if s.target.IsValid() {
+		return s.target.String()
+	}
+	return net.JoinHostPort("localhost", strconv.Itoa(int(s.port)))
 }
 
 func runForward(ctx context.Context, logf logger.Logf, bind string, args []string) error {
@@ -70,23 +86,23 @@ func runForward(ctx context.Context, logf logger.Logf, bind string, args []strin
 		_ = cl.Close()
 	}()
 	for _, spec := range args[1:] {
-		listenAddr, remotePort, err := parseForwardSpec(bind, spec)
+		mapping, err := parseForwardSpec(bind, spec)
 		if err != nil {
 			for _, ln := range listeners {
 				ln.Close()
 			}
 			return usagef("mapping %q is invalid: %v", spec, err)
 		}
-		ln, err := net.Listen("tcp", listenAddr)
+		ln, err := net.Listen("tcp", mapping.listenAddr)
 		if err != nil {
 			for _, old := range listeners {
 				old.Close()
 			}
-			return fmt.Errorf("listen on %s: %w", listenAddr, err)
+			return fmt.Errorf("listen on %s: %w", mapping.listenAddr, err)
 		}
 		listeners = append(listeners, ln)
 		listenersWG.Add(1)
-		go forwardListener(ctx, logf, cl, ln, remotePort, &listenersWG, &connectionsWG, &active)
+		go forwardListener(ctx, logf, cl, ln, mapping, &listenersWG, &connectionsWG, &active)
 	}
 
 	<-ctx.Done()
@@ -96,12 +112,12 @@ func runForward(ctx context.Context, logf logger.Logf, bind string, args []strin
 	return nil
 }
 
-func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, ln net.Listener, remotePort uint16, listenersWG, connectionsWG *sync.WaitGroup, active *sync.Map) {
+func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, ln net.Listener, mapping forwardSpec, listenersWG, connectionsWG *sync.WaitGroup, active *sync.Map) {
 	defer listenersWG.Done()
 	// Print unconditionally (not via the verbose-only logf): with a
 	// local port of 0 this line is the only way to learn which port
 	// the OS picked.
-	log.Printf("forwarding %s -> remote localhost:%d", ln.Addr(), remotePort)
+	log.Printf("forwarding %s -> remote %s", ln.Addr(), mapping.remoteTarget())
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -113,10 +129,16 @@ func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, 
 			defer connectionsWG.Done()
 			defer active.Delete(conn)
 			defer conn.Close()
-			remote, err := cl.DialTCPPort(ctx, remotePort)
+			var remote net.Conn
+			var err error
+			if mapping.target.IsValid() {
+				remote, err = cl.DialTCP(ctx, mapping.target)
+			} else {
+				remote, err = cl.DialTCPPort(ctx, mapping.port)
+			}
 			if err != nil {
 				if ctx.Err() == nil {
-					logf("dial remote port %d: %v", remotePort, err)
+					logf("dial remote target %s: %v", mapping.remoteTarget(), err)
 				}
 				return
 			}
@@ -125,23 +147,38 @@ func forwardListener(ctx context.Context, logf logger.Logf, cl *tailcat.Client, 
 	}
 }
 
-func parseForwardSpec(bind, spec string) (string, uint16, error) {
-	local, remote, hasColon := strings.Cut(spec, ":")
+func parseForwardSpec(bind, spec string) (forwardSpec, error) {
+	local, target, hasColon := strings.Cut(spec, ":")
 	if !hasColon {
-		remote = local
-	}
-	remotePort, err := parseForwardPort(remote)
-	if err != nil {
-		return "", 0, fmt.Errorf("remote port: %w", err)
+		target = local
 	}
 	var localPort uint16
+	var err error
 	if !hasColon || local != "0" { // local port 0 asks the OS for a free port
 		localPort, err = parseForwardPort(local)
 		if err != nil {
-			return "", 0, fmt.Errorf("local port: %w", err)
+			return forwardSpec{}, fmt.Errorf("local port: %w", err)
 		}
 	}
-	return net.JoinHostPort(bind, strconv.Itoa(int(localPort))), remotePort, nil
+	mapping := forwardSpec{listenAddr: net.JoinHostPort(bind, strconv.Itoa(int(localPort)))}
+	if !hasColon {
+		mapping.port, err = parseForwardPort(target)
+		if err != nil {
+			return forwardSpec{}, fmt.Errorf("remote port: %w", err)
+		}
+		return mapping, nil
+	}
+	remotePort, err := parseForwardPort(target)
+	if err == nil {
+		mapping.port = remotePort
+		return mapping, nil
+	}
+	remoteAddr, err := netip.ParseAddrPort(target)
+	if err != nil {
+		return forwardSpec{}, fmt.Errorf("remote target %q is not a port or address:port", target)
+	}
+	mapping.target = remoteAddr
+	return mapping, nil
 }
 
 func parseForwardPort(s string) (uint16, error) {

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -41,7 +41,11 @@ func TestParseForwardSpec(t *testing.T) {
 				}
 				return
 			}
-			if err != nil || got.listenAddr != tt.wantAddr || got.port != tt.wantPort || got.target.String() != tt.wantTarget {
+			wantTarget := ""
+			if got.target.IsValid() {
+				wantTarget = got.target.String()
+			}
+			if err != nil || got.listenAddr != tt.wantAddr || got.port != tt.wantPort || wantTarget != tt.wantTarget {
 				t.Fatalf("parseForwardSpec(%q) = %#v, %v; want address %q, port %d, target %q", tt.spec, got, err, tt.wantAddr, tt.wantPort, tt.wantTarget)
 			}
 		})

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,26 +19,30 @@ func TestParseForwardSpec(t *testing.T) {
 	for _, tt := range []struct {
 		spec, wantAddr string
 		wantPort       uint16
+		wantTarget     string
 		wantErr        bool
 	}{
-		{"8080", "127.0.0.1:8080", 8080, false},
-		{"18080:8080", "127.0.0.1:18080", 8080, false},
-		{"1:65535", "127.0.0.1:1", 65535, false},
-		{"0", "", 0, true},
-		{"0:8080", "127.0.0.1:0", 8080, false},
-		{"8080:0", "", 0, true},
-		{"8080:bad", "", 0, true},
+		{"8080", "127.0.0.1:8080", 8080, "", false},
+		{"18080:8080", "127.0.0.1:18080", 8080, "", false},
+		{"1:65535", "127.0.0.1:1", 65535, "", false},
+		{"0", "", 0, "", true},
+		{"0:8080", "127.0.0.1:0", 8080, "", false},
+		{"13306:192.168.1.10:3306", "127.0.0.1:13306", 0, "192.168.1.10:3306", false},
+		{"13306:[2001:db8::10]:3306", "127.0.0.1:13306", 0, "[2001:db8::10]:3306", false},
+		{"8080:0", "", 0, "", true},
+		{"8080:bad", "", 0, "", true},
+		{"8080:192.168.1.10:bad", "", 0, "", true},
 	} {
 		t.Run(tt.spec, func(t *testing.T) {
-			gotAddr, gotPort, err := parseForwardSpec("127.0.0.1", tt.spec)
+			got, err := parseForwardSpec("127.0.0.1", tt.spec)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("parseForwardSpec succeeded; want error")
 				}
 				return
 			}
-			if err != nil || gotAddr != tt.wantAddr || gotPort != tt.wantPort {
-				t.Fatalf("parseForwardSpec(%q) = %q, %d, %v; want %q, %d", tt.spec, gotAddr, gotPort, err, tt.wantAddr, tt.wantPort)
+			if err != nil || got.listenAddr != tt.wantAddr || got.port != tt.wantPort || got.target.String() != tt.wantTarget {
+				t.Fatalf("parseForwardSpec(%q) = %#v, %v; want address %q, port %d, target %q", tt.spec, got, err, tt.wantAddr, tt.wantPort, tt.wantTarget)
 			}
 		})
 	}
@@ -48,13 +53,6 @@ func TestForwardEndToEnd(t *testing.T) {
 	remotePort := startEchoListener(t)
 
 	_, tailcatAddr, serverStderr := e.startServer("--verbose", "serve", strconv.Itoa(int(remotePort)))
-
-	// Forward from local port 0 (OS-assigned) and learn the picked
-	// address from the "forwarding" line on stderr. Pre-picking a free
-	// port here and passing it explicitly would race other processes
-	// on this machine binding it first. Stderr goes to a file, polled
-	// below, because reading a shared buffer while the process writes
-	// it would race.
 	forward := e.cmd("--verbose", "--key=new", "--derpmap-url="+e.derpMapURL, "forward", tailcatAddr, fmt.Sprintf("0:%d", remotePort))
 	stderrPath := filepath.Join(t.TempDir(), "forward.stderr")
 	stderrFile, err := os.Create(stderrPath)
@@ -97,6 +95,65 @@ func TestForwardEndToEnd(t *testing.T) {
 	defer conn.Close()
 
 	const payload = "forwarded over tailcat"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := conn.Read(got); err != nil {
+		t.Fatalf("read: %v\nforward stderr:\n%s\nserver stderr:\n%s", err, forwardStderr(), serverStderr)
+	}
+	if string(got) != payload {
+		t.Errorf("got %q; want %q", got, payload)
+	}
+}
+
+func TestForwardToExitNodeTarget(t *testing.T) {
+	e := newTestEnv(t)
+	remotePort := startEchoListener(t)
+	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), remotePort)
+
+	_, tailcatAddr, serverStderr := e.startServer("--verbose", "serve", "exit-node")
+	forward := e.cmd("--verbose", "--key=new", "--derpmap-url="+e.derpMapURL, "forward", tailcatAddr, fmt.Sprintf("0:%s", dst))
+	stderrPath := filepath.Join(t.TempDir(), "forward-exit-node.stderr")
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stderrFile.Close()
+	forward.Stderr = stderrFile
+	if err := forward.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = forward.Process.Kill()
+		_ = forward.Wait()
+	})
+	forwardStderr := func() string {
+		b, _ := os.ReadFile(stderrPath)
+		return string(b)
+	}
+
+	addrRx := regexp.MustCompile(`forwarding (\S+) ->`)
+	var addr string
+	deadline := time.Now().Add(30 * time.Second)
+	for addr == "" {
+		if time.Now().After(deadline) {
+			t.Fatalf("forward never listened; stderr:\n%s\nserver stderr:\n%s", forwardStderr(), serverStderr)
+		}
+		if m := addrRx.FindStringSubmatch(forwardStderr()); m != nil {
+			addr = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	const payload = "forwarded to an exit-node target"
 	if _, err := conn.Write([]byte(payload)); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What does this change do?

Extend the `tailcat forward` subcommand to forward local TCP ports to
arbitrary IP:port targets reachable through a Tailcat server running as an
exit node.

This is useful for accessing TCP services on remote network assets through
an exit-node server, including applications that only support regular
`host:port` connections and do not provide Tailnet, SOCKS, or stdio proxy
integration.

The mapping syntax for exit-node targets is:

```text
<local-port>:<remote-ip>:<remote-port>
```

The `<addrblob>` argument is the address blob printed by `tailcat serve`,
typically a value beginning with `tc`.

Related to #14.

## Examples

Start a Tailcat server in exit-node mode:

```sh
tailcat serve exit-node
# Server listening with new address: tcXXXXXXXXX
```

Forward local ports to two remote network assets:

```sh
tailcat forward tcXXXXXXXXX \
    3001:172.23.52.30:3001 \
    17170:172.23.52.31:17170
```

This forwards:

```text
127.0.0.1:3001  -> Tailcat -> exit-node -> 172.23.52.30:3001
127.0.0.1:17170 -> Tailcat -> exit-node -> 172.23.52.31:17170
```

Regular forwarding to ports served directly by the Tailcat server continues
to work:

```sh
tailcat serve 8080,3306
# Server listening with new address: tcXXXXXXXXX

tailcat forward tcXXXXXXXXX 18080:8080 3306
```

By default, local listeners bind to `127.0.0.1`. Use `--bind` when a
specific local address is required:

```sh
tailcat forward --bind=0.0.0.0 tcXXXXXXXXX \
    3001:172.23.52.30:3001 \
    17170:172.23.52.31:17170
```

Use `--bind=0.0.0.0` only when intentionally allowing connections from
other network interfaces.

## Design

- Reuses one Tailcat client for all forwarded ports.
- Uses the existing `Client.DialTCP` API for exit-node IP:port targets.
- Uses the existing `Client.DialTCPPort` API for ports served by Tailcat.
- Uses the existing `ProxyConns` helper.
- Supports regular `<remote-port>` and `<local>:<remote-port>` mappings.
- Supports multiple local-to-remote mappings in one command.
- Supports IPv4 and IPv6 IP:port targets.
- Binds to `127.0.0.1` by default.
- Does not change the Tailcat protocol or server behavior.
- Does not introduce a new dependency.

## Testing

- Added unit test coverage for regular and exit-node target mapping parsing.
- Added an end-to-end test for forwarding to an exit-node target.
- Preserved the existing end-to-end test for forwarding to a Tailcat-served
  port.
- Verified multiple exit-node target mappings manually.

Tested with:

```sh
go test ./cmd/tailcat -run '^TestForward(ToExitNodeTarget|EndToEnd)$' -v
```