### PR TITLE
docs: Mention conda-forge installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ yay -S tailcat
 yay -S tailcat-bin
 ```
 
+Or from conda-forge:
+
+[![tailcat on conda-forge](https://img.shields.io/conda/vn/conda-forge/tailcat?logo=conda-forge)](https://prefix.dev/channels/conda-forge/packages/tailcat)
+[![tailcat on conda-forge](https://img.shields.io/conda/pn/conda-forge/tailcat?logo=conda-forge)](https://prefix.dev/channels/conda-forge/packages/tailcat)
+
+```bash
+pixi global install tailcat
+# run without installation
+pixi exec tailcat
+```
+
 ### Packaging from source
 
 The official binaries are built with a list of build tags that omits


### PR DESCRIPTION
I built tailcat on conda-forge for the following platforms:

- linux x86_64
- linux aarch64
- linux ppc64le
- linux riscv64
- windows x86_64
- windows arm64
- macos x86_64
- macos arm64

[pixi](https://pixi.sh) is a modern cross-platform package manager that interacts with the conda-forge ecosystem.

<img width="1047" height="212" alt="image" src="https://github.com/user-attachments/assets/fd2e5bc5-882c-4ee3-96d1-4ed28e5e2d1e" />
