### PR TITLE
go.mod: bump tailscale.com to deflake tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,4 +37,4 @@
         };
       });
 }
-# nix-direnv cache busting line: sha256-lznT3EXFHsTS9nn7mVheWJw+2uDtsh1gljqEHxnbdso=
+# nix-direnv cache busting line: sha256-oB682FyWyy4fmwimoco878dcfvf795QN9+nHA7D8ZuY=

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -1,6 +1,6 @@
 {
   "vendor": {
-    "goModSum": "sha256-QB8SdTuhCENpZhUhLT3xl4LmagjedXJtan+s/8IdrAo=",
-    "sri": "sha256-lznT3EXFHsTS9nn7mVheWJw+2uDtsh1gljqEHxnbdso="
+    "goModSum": "sha256-HIqwAVZMszb9LkPK9W8j31G7taNfJrFpKjhPGSApC1Y=",
+    "sri": "sha256-oB682FyWyy4fmwimoco878dcfvf795QN9+nHA7D8ZuY="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/tailcat
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f
@@ -19,7 +19,7 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sys v0.47.0
 	gvisor.dev/gvisor v0.0.0-20260224225140-573d5e7127a8
-	tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8
+	tailscale.com v1.103.0-pre.0.20260903171501-92ec102673bf
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -311,5 +311,5 @@ howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8 h1:Ow72mYrStZyFA3kwBBACYJZ5EkicN7fc3IEQh/U7HBA=
-tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8/go.mod h1:0FUeNgU+WylKFtsg4LOZQxceO16WyN9YjvrxmUiilbs=
+tailscale.com v1.103.0-pre.0.20260903171501-92ec102673bf h1:gnL539WILeqA+MNAxYM9NYrpTHi2XLkM4v0Aasvh0XA=
+tailscale.com v1.103.0-pre.0.20260903171501-92ec102673bf/go.mod h1:WP0idIS/E7KeobO20C5Z0tylXbZKbz26FqH9gcxxk0I=


### PR DESCRIPTION
(This also brings in upstream's Go 1.27.1 go.mod bump)

Updates tailscale/tailscale#21086
Fixes #73
