### PR TITLE
tailcat, cmd/tailcat: add exit-node UDP forwarding

### DIFF
--- a/cmd/tailcat/serve_test.go
+++ b/cmd/tailcat/serve_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -14,8 +15,12 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/tailscale/tailcat"
+	"tailscale.com/types/nettype"
 )
 
 // startEchoListener starts a TCP echo server on a 127.0.0.1 ephemeral
@@ -229,4 +234,134 @@ func socks5Connect(t *testing.T, proxyAddr string, dst netip.AddrPort) net.Conn 
 	}
 	c.SetDeadline(time.Time{})
 	return c
+}
+
+func TestServeExitNodeUDP(t *testing.T) {
+	e := newTestEnv(t)
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pc.Close()
+	port := pc.LocalAddr().(*net.UDPAddr).Port
+	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), uint16(port))
+
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, from, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			_, _ = pc.WriteTo(buf[:n], from)
+		}
+	}()
+
+	_, addr, _ := e.startServer("--serve=exit-node")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := tailcat.NewClient(tailcat.Addr(addr))
+	client.DERPMapURL = e.derpMapURL
+	defer client.Close()
+
+	conn, err := client.DialUDP(ctx, dst)
+	if err != nil {
+		t.Fatalf("DialUDP: %v", err)
+	}
+	defer conn.Close()
+
+	const msg = "udp echo through tailcat exit node"
+	if _, err := conn.Write([]byte(msg)); err != nil {
+		t.Fatalf("Write UDP: %v", err)
+	}
+
+	replyBuf := make([]byte, len(msg))
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	n, err := conn.Read(replyBuf)
+	if err != nil {
+		t.Fatalf("Read UDP reply: %v", err)
+	}
+	if string(replyBuf[:n]) != msg {
+		t.Fatalf("UDP echo got %q, want %q", string(replyBuf[:n]), msg)
+	}
+
+	if !client.HasServerCap(tailcat.CapExitUDP) {
+		t.Errorf("server did not advertise CapExitUDP: caps = %02x", client.ServerCaps())
+	}
+
+	if _, err := conn.Write([]byte{}); err != nil {
+		t.Fatalf("Write zero-length UDP: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	zeroReply := make([]byte, 100)
+	nZero, err := conn.Read(zeroReply)
+	if err != nil {
+		t.Fatalf("Read zero-length UDP reply: %v", err)
+	}
+	if nZero != 0 {
+		t.Fatalf("expected zero-length reply, got %d bytes", nZero)
+	}
+}
+
+func TestAllowProxyRejection(t *testing.T) {
+	e := newTestEnv(t)
+
+	var tcpForwardInvoked atomic.Bool
+	var udpForwardInvoked atomic.Bool
+
+	echoPort := startEchoListener(t)
+	allowedDst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), echoPort)
+	prohibitedDst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), 80)
+
+	srv := &tailcat.Server{
+		DERPMapURL: e.derpMapURL,
+		AllowProxy: func(dst netip.AddrPort) bool {
+			return dst == allowedDst
+		},
+		OnTCPForward: func(dst netip.AddrPort) func(net.Conn) {
+			tcpForwardInvoked.Store(true)
+			return func(c net.Conn) { c.Close() }
+		},
+		OnUDPForward: func(dst netip.AddrPort) func(nettype.ConnPacketConn) {
+			udpForwardInvoked.Store(true)
+			return func(c nettype.ConnPacketConn) { c.Close() }
+		},
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatalf("srv.Start: %v", err)
+	}
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	client := tailcat.NewClient(srv.TailcatAddr())
+	client.DERPMapURL = e.derpMapURL
+	defer client.Close()
+
+	tcpConn, err := client.DialTCP(ctx, prohibitedDst)
+	if err == nil {
+		buf := make([]byte, 10)
+		_ = tcpConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		_, _ = tcpConn.Read(buf)
+		tcpConn.Close()
+	}
+	if tcpForwardInvoked.Load() {
+		t.Errorf("OnTCPForward was invoked for prohibited destination %v", prohibitedDst)
+	}
+
+	udpConn, err := client.DialUDP(ctx, prohibitedDst)
+	if err == nil {
+		_, _ = udpConn.Write([]byte("prohibited-udp-packet"))
+		_ = udpConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		buf := make([]byte, 100)
+		_, _ = udpConn.Read(buf)
+		udpConn.Close()
+	}
+	if udpForwardInvoked.Load() {
+		t.Errorf("OnUDPForward was invoked for prohibited destination %v", prohibitedDst)
+	}
 }

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -43,6 +43,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
+	"tailscale.com/types/nettype"
 	"tailscale.com/util/set"
 	"tailscale.com/wgengine/filter"
 )
@@ -1250,9 +1251,60 @@ func server(logf logger.Logf, serveSpec string) {
 		}
 	}
 
+	udpForwardTo := func(ipPortStr string) func(nettype.ConnPacketConn) {
+		return func(c nettype.ConnPacketConn) {
+			defer c.Close()
+			rAddr, err := net.ResolveUDPAddr("udp", ipPortStr)
+			if err != nil {
+				logf("error resolving UDP %v: %v", ipPortStr, err)
+				return
+			}
+			remoteConn, err := net.DialUDP("udp", nil, rAddr)
+			if err != nil {
+				logf("error dialing UDP to %v: %v", ipPortStr, err)
+				return
+			}
+			defer remoteConn.Close()
+
+			done := make(chan struct{}, 2)
+			go func() {
+				buf := make([]byte, 65535)
+				for {
+					_ = c.SetReadDeadline(time.Now().Add(60 * time.Second))
+					n, err := c.Read(buf)
+					if err != nil {
+						break
+					}
+					if _, err := remoteConn.Write(buf[:n]); err != nil {
+						break
+					}
+				}
+				done <- struct{}{}
+			}()
+			go func() {
+				buf := make([]byte, 65535)
+				for {
+					_ = remoteConn.SetReadDeadline(time.Now().Add(60 * time.Second))
+					n, err := remoteConn.Read(buf)
+					if err != nil {
+						break
+					}
+					if _, err := c.Write(buf[:n]); err != nil {
+						break
+					}
+				}
+				done <- struct{}{}
+			}()
+			<-done
+		}
+	}
+
 	if services.Contains("exit-node") {
 		s.OnTCPForward = func(dst netip.AddrPort) (handler func(net.Conn)) {
 			return tcpForwardTo(dst.String())
+		}
+		s.OnUDPForward = func(dst netip.AddrPort) (handler func(nettype.ConnPacketConn)) {
+			return udpForwardTo(dst.String())
 		}
 	}
 

--- a/disco.go
+++ b/disco.go
@@ -68,3 +68,26 @@ func ParseMeowPing(pkt []byte) (nodeKey key.NodePublic, discoKey key.DiscoPublic
 func IsMeowedPacket(pkt []byte) bool {
 	return len(pkt) >= 5 && [4]byte(pkt[:4]) == meowMagic && pkt[4] == meowTypePong
 }
+
+// Exit node capability flags advertised in a meowed acknowledgment packet.
+const (
+	CapExitTCP uint8 = 1 << 0 // server supports exit-node TCP forwarding
+	CapExitUDP uint8 = 1 << 1 // server supports exit-node UDP forwarding
+)
+
+// EncodeMeowedWithCaps encodes a meowed packet with a capability trailer.
+func EncodeMeowedWithCaps(caps uint8) []byte {
+	b := make([]byte, 0, 4+1+1)
+	b = append(b, meowMagic[:]...)
+	b = append(b, meowTypePong, caps)
+	return b
+}
+
+// ParseMeowedCaps returns the capability flags from a meowed packet.
+// Legacy 5-byte meowed packets (no trailer) return 0.
+func ParseMeowedCaps(pkt []byte) uint8 {
+	if len(pkt) >= 6 && IsMeowedPacket(pkt) {
+		return pkt[5]
+	}
+	return 0
+}

--- a/disco_test.go
+++ b/disco_test.go
@@ -47,6 +47,23 @@ func TestMeowedRoundTrip(t *testing.T) {
 	if _, _, ok := ParseMeowPing(pkt); ok {
 		t.Error("ParseMeowPing accepted a meowed packet")
 	}
+	if ParseMeowedCaps(pkt) != 0 {
+		t.Errorf("legacy meowed caps = %d; want 0", ParseMeowedCaps(pkt))
+	}
+}
+
+func TestMeowedCapsRoundTrip(t *testing.T) {
+	want := CapExitTCP | CapExitUDP
+	pkt := EncodeMeowedWithCaps(want)
+	if !IsMeowedPacket(pkt) {
+		t.Fatal("EncodeMeowedWithCaps output is not a meowed packet")
+	}
+	if got := ParseMeowedCaps(pkt); got != want {
+		t.Errorf("ParseMeowedCaps = %02x; want %02x", got, want)
+	}
+	if ParseMeowedCaps(EncodeMeowed()) != 0 {
+		t.Error("ParseMeowedCaps of 5-byte meowed must be 0")
+	}
 }
 
 func TestIsMeowPacket(t *testing.T) {

--- a/tailcat.go
+++ b/tailcat.go
@@ -76,6 +76,7 @@ import (
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/types/netmap"
+	"tailscale.com/types/nettype"
 	"tailscale.com/types/views"
 	"tailscale.com/util/eventbus"
 	"tailscale.com/util/mak"
@@ -374,6 +375,17 @@ type Server struct {
 	// destination, not just the server's own address.
 	OnTCPForward func(netip.AddrPort) (handler func(net.Conn))
 
+	// OnUDPForward, if non-nil, specifies a func that returns a handler to handle
+	// incoming UDP packets to the provided IP:port. If nil or if it returns nil,
+	// then the packet is dropped.
+	//
+	// This only applies to UDP packets relayed through the server (exit node mode)
+	// and not to the server itself.
+	//
+	// It must be set before calling Start. Setting it also widens the
+	// packet filter installed at Start to admit UDP traffic to any destination.
+	OnUDPForward func(netip.AddrPort) (handler func(nettype.ConnPacketConn))
+
 	// ServedTCPPorts, if non-nil, restricts which TCP ports on the
 	// server's own address the packet filter admits new inbound
 	// connections to. If nil, connections to all ports reach OnTCP,
@@ -466,7 +478,14 @@ func (s *Server) Start() error {
 				// "meowed" is the ack that tells the client it can
 				// start dialing. Disallowed clients get no reply.
 				if lb.onMeow(src, discoPub) {
-					mc.SendDERPPacketTo(src, regionID, EncodeMeowed())
+					var caps uint8
+					if s.OnTCPForward != nil {
+						caps |= CapExitTCP
+					}
+					if s.OnUDPForward != nil {
+						caps |= CapExitUDP
+					}
+					mc.SendDERPPacketTo(src, regionID, EncodeMeowedWithCaps(caps))
 				}
 			}()
 			return true
@@ -501,7 +520,25 @@ func (s *Server) Start() error {
 			copy(a4[:], d6[12:16])
 			dst = netip.AddrPortFrom(netip.AddrFrom4(a4), dst.Port())
 		}
+		if s.AllowProxy != nil && !s.AllowProxy(dst) {
+			return nil, true // send RST
+		}
 		return s.OnTCPForward(dst), true
+	}
+	ns.GetUDPHandlerForFlow = func(src, dst netip.AddrPort) (handler func(nettype.ConnPacketConn), intercept bool) {
+		if s.OnUDPForward == nil {
+			return nil, true
+		}
+		if nat64Prefix.Contains(dst.Addr()) {
+			var a4 [4]byte
+			d6 := dst.Addr().As16()
+			copy(a4[:], d6[12:16])
+			dst = netip.AddrPortFrom(netip.AddrFrom4(a4), dst.Port())
+		}
+		if s.AllowProxy != nil && !s.AllowProxy(dst) {
+			return nil, true
+		}
+		return s.OnUDPForward(dst), true
 	}
 	lb.ns = ns
 	sys.Set(ns)
@@ -514,7 +551,7 @@ func (s *Server) Start() error {
 		return ns.DialContextTCP(ctx, dst)
 	}
 	dialer.NetstackDialUDP = func(ctx context.Context, dst netip.AddrPort) (net.Conn, error) {
-		panic("unreachable from tailcat") // but required by Dialer currently
+		return ns.DialContextUDP(ctx, dst)
 	}
 
 	sys.Tun.Get().Start()
@@ -557,10 +594,19 @@ func (s *Server) buildFilter() *filter.Filter {
 
 	var localNets netipx.IPSetBuilder
 	localNets.AddPrefix(lb.addrPrefix)
-	if s.OnTCPForward != nil {
+	if s.OnTCPForward != nil || s.OnUDPForward != nil {
 		localNets.AddPrefix(allIPv6)
+	}
+	if s.OnTCPForward != nil {
 		matches = append(matches, filter.Match{
 			IPProto: views.SliceOf([]ipproto.Proto{ipproto.TCP}),
+			Srcs:    []netip.Prefix{allIPv6},
+			Dsts:    []filter.NetPortRange{{Net: allIPv6, Ports: allTCPPorts}},
+		})
+	}
+	if s.OnUDPForward != nil {
+		matches = append(matches, filter.Match{
+			IPProto: views.SliceOf([]ipproto.Proto{ipproto.UDP}),
 			Srcs:    []netip.Prefix{allIPv6},
 			Dsts:    []filter.NetPortRange{{Net: allIPv6, Ports: allTCPPorts}},
 		})
@@ -1534,7 +1580,8 @@ type Client struct {
 	key     key.NodePrivate // the effective node identity; Key or generated
 	started bool
 
-	upDone atomic.Bool // whether the server has meowed us at least once
+	serverCaps atomic.Uint32 // capability bitfield from server's meowed response
+	upDone     atomic.Bool   // whether the server has meowed us at least once
 }
 
 // nodeKeyLocked returns the client's effective node private key,
@@ -1617,6 +1664,7 @@ func (c *Client) initLocked() error {
 			return false
 		}
 		if IsMeowedPacket(pkt) {
+			c.serverCaps.Store(uint32(ParseMeowedCaps(pkt)))
 			go onMeowed()
 			return true
 		}
@@ -1656,7 +1704,7 @@ func (c *Client) initLocked() error {
 		return ns.DialContextTCP(ctx, dst)
 	}
 	dialer.NetstackDialUDP = func(ctx context.Context, dst netip.AddrPort) (net.Conn, error) {
-		panic("unreachable from tailcat") // but required by Dialer currently
+		return ns.DialContextUDP(ctx, dst)
 	}
 	sys.Tun.Get().Start()
 
@@ -1906,6 +1954,34 @@ func (c *Client) DialTCP(ctx context.Context, ap netip.AddrPort) (net.Conn, erro
 		ap = netip.AddrPortFrom(netip.AddrFrom16(a), ap.Port())
 	}
 	return c.lb.ns.DialContextTCP(ctx, ap)
+}
+
+// ServerCaps returns the capability bitfield advertised by the server in its meowed response.
+func (c *Client) ServerCaps() uint8 {
+	return uint8(c.serverCaps.Load())
+}
+
+// HasServerCap reports whether the server advertised the specified capability.
+func (c *Client) HasServerCap(cap uint8) bool {
+	return (c.ServerCaps() & cap) != 0
+}
+
+// DialUDP opens a UDP connection to an arbitrary IP:port through the server,
+// which must be configured as an exit node (see [Server.OnUDPForward]).
+// IPv4 addresses are mapped into the NAT64 prefix (64:ff9b::/96) for
+// transport over the IPv6-only WireGuard tunnel.
+// See [Client.Dial] for the lazy startup behavior.
+func (c *Client) DialUDP(ctx context.Context, ap netip.AddrPort) (net.Conn, error) {
+	if err := c.up(ctx); err != nil {
+		return nil, err
+	}
+	if ap.Addr().Is4() {
+		a := nat64PrefixBytes
+		a4 := ap.Addr().As4()
+		copy(a[12:], a4[:])
+		ap = netip.AddrPortFrom(netip.AddrFrom16(a), ap.Port())
+	}
+	return c.lb.ns.DialContextUDP(ctx, ap)
 }
 
 func pfxOf(a netip.Addr) netip.Prefix {


### PR DESCRIPTION
## Why

`Server.OnTCPForward` already makes `tailcat serve exit-node` a TCP exit node. UDP is still a dead end: `NetstackDialUDP` panics (`unreachable from tailcat`) and `buildFilter` never admits `ipproto.UDP`, so a client TUN cannot send QUIC, DNS, or other datagrams through the tunnel.

`AllowProxy` is already documented as applying to TCP **or UDP**, but it was never consulted on the TCP path either.

## What

- `Server.OnUDPForward` plus `GetUDPHandlerForFlow`, same NAT64 unwrap as TCP
- Packet filter admits UDP to any destination when `OnUDPForward` is set
- `NetstackDialUDP` → `ns.DialContextUDP` on both server and client
- `Client.DialUDP` / `HasServerCap` / `ServerCaps`
- Capability trailer on meowed: `CapExitTCP` (0x01), `CapExitUDP` (0x02). Legacy 5-byte meowed still parses as caps=0
- `AllowProxy` enforced on both TCP and UDP exit flows
- CLI `serve exit-node` copies datagrams (60s idle, 65535-byte buffers)

Caller-defined `AllowProxy` stays the policy hook; this PR does not bake in loopback/metadata denials.

## Tests

- `go test .` (includes `TestMeowedCapsRoundTrip`)
- `go test ./cmd/tailcat -run 'TestServeExitNodeUDP|TestAllowProxyRejection|TestServeExitNode$'`
- `go vet ./...`