### PR TITLE
tailcat: let proxied gVisor TCP connections finish teardown

### DIFF
--- a/tailcat.go
+++ b/tailcat.go
@@ -58,8 +58,10 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	go4mem "go4.org/mem"
 	"go4.org/netipx"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/waiter"
 	"tailscale.com/disco"
 	"tailscale.com/envknob"
 	"tailscale.com/health"
@@ -1943,8 +1945,77 @@ func ProxyConns(a, b net.Conn) {
 	go cp(a, b)
 	go cp(b, a)
 	wg.Wait()
-	a.Close()
-	b.Close()
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		closeProxyConn(a)
+	}()
+	go func() {
+		defer wg.Done()
+		closeProxyConn(b)
+	}()
+	wg.Wait()
+}
+
+const proxyConnDrainTimeout = 5 * time.Second
+
+// closeProxyConn waits up to proxyConnDrainTimeout for a gVisor TCP connection
+// whose peer has already closed to acknowledge our FIN, then closes it.
+// Calling Close immediately after CloseWrite can race gVisor's protocol
+// teardown and lose the FIN if its first transmission is dropped. Other
+// connections can be closed immediately.
+func closeProxyConn(c net.Conn) {
+	closeProxyConnTimeout(c, proxyConnDrainTimeout)
+}
+
+func closeProxyConnTimeout(c net.Conn, timeout time.Duration) {
+	if c, ok := c.(*gonet.TCPConn); ok {
+		ep, wq := gonetTCPConnInternals(c)
+		e, ch := waiter.NewChannelEntry(waiter.EventHUp)
+		wq.EventRegister(&e)
+		// Check after registering so a concurrent state transition cannot be
+		// missed between observing the state and subscribing to its event.
+		timer := time.NewTimer(timeout)
+		for {
+			switch tcp.EndpointState(ep.State()) {
+			case tcp.StateClosing, tcp.StateLastAck:
+			default:
+				timer.Stop()
+				wq.EventUnregister(&e)
+				c.Close()
+				return
+			}
+			select {
+			case <-ch:
+			case <-timer.C:
+				wq.EventUnregister(&e)
+				c.Close()
+				return
+			}
+		}
+	}
+	c.Close()
+}
+
+type tcpStateEndpoint interface {
+	State() uint32
+}
+
+// gonetTCPConnInternals returns c's unexported gVisor TCP endpoint and waiter
+// queue.
+//
+// TODO(bradfitz): add an exported accessor upstream and delete this
+// reflect+unsafe cheat.
+func gonetTCPConnInternals(c *gonet.TCPConn) (ep tcpStateEndpoint, wq *waiter.Queue) {
+	cv := reflect.ValueOf(c).Elem()
+	epv := cv.FieldByName("ep")
+	wqv := cv.FieldByName("wq")
+	if !epv.IsValid() || !wqv.IsValid() {
+		panic("gonet.TCPConn internals changed in gVisor dependency")
+	}
+	ep = reflect.NewAt(epv.Type(), unsafe.Pointer(epv.UnsafeAddr())).Elem().Interface().(tcpStateEndpoint)
+	wq = reflect.NewAt(wqv.Type(), unsafe.Pointer(wqv.UnsafeAddr())).Elem().Interface().(*waiter.Queue)
+	return ep, wq
 }
 
 // Status returns the current WireGuard and DERP connection status.

--- a/tailcat_test.go
+++ b/tailcat_test.go
@@ -21,12 +21,196 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/google/go-cmp/cmp"
 	"go4.org/mem"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest/integration"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/wgengine/filter"
 )
+
+const testNICID = 1
+
+func newTestTCPStack(t *testing.T, addr tcpip.Address) (*stack.Stack, *channel.Endpoint) {
+	t.Helper()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol},
+	})
+	ep := channel.New(16, 1500, "")
+	if err := s.CreateNIC(testNICID, ep); err != nil {
+		t.Fatalf("CreateNIC: %v", err)
+	}
+	if err := s.AddProtocolAddress(testNICID, tcpip.ProtocolAddress{
+		Protocol:          ipv4.ProtocolNumber,
+		AddressWithPrefix: addr.WithPrefix(),
+	}, stack.AddressProperties{}); err != nil {
+		t.Fatalf("AddProtocolAddress: %v", err)
+	}
+	s.SetRouteTable([]tcpip.Route{{Destination: header.IPv4EmptySubnet, NIC: testNICID}})
+	t.Cleanup(func() {
+		ep.Close()
+		s.Close()
+		s.Wait()
+	})
+	return s, ep
+}
+
+func relayTestPackets(ctx context.Context, src, dst *channel.Endpoint, packet func(*stack.PacketBuffer) bool) {
+	for {
+		pkt := src.ReadContext(ctx)
+		if pkt == nil {
+			return
+		}
+		forward := packet == nil || packet(pkt)
+		if forward {
+			in := stack.NewPacketBuffer(stack.PacketBufferOptions{Payload: pkt.ToBuffer()})
+			dst.InjectInbound(pkt.NetworkProtocolNumber, in)
+			in.DecRef()
+		}
+		pkt.DecRef()
+	}
+}
+
+func testPacketTCPFlags(pkt *stack.PacketBuffer) header.TCPFlags {
+	v := pkt.ToView()
+	defer v.Release()
+	ip := header.IPv4(v.AsSlice())
+	if ip.TransportProtocol() != tcp.ProtocolNumber {
+		return 0
+	}
+	return header.TCP(ip[ip.HeaderLength():]).Flags()
+}
+
+type testTCPStateEndpoint interface {
+	tcpStateEndpoint
+	LockUser()
+	UnlockUser()
+}
+
+func checkTestTCPState(t *testing.T, c *gonet.TCPConn, want tcp.EndpointState) {
+	t.Helper()
+	ep, _ := gonetTCPConnInternals(c)
+	lep := ep.(testTCPStateEndpoint)
+	lep.LockUser()
+	got := tcp.EndpointState(ep.State())
+	lep.UnlockUser()
+	if got != want {
+		t.Fatalf("TCP state = %v; want %v", got, want)
+	}
+}
+
+func TestCloseProxyConnRetransmitsFIN(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	clientAddr := tcpip.AddrFrom4([4]byte{192, 0, 2, 1})
+	serverAddr := tcpip.AddrFrom4([4]byte{192, 0, 2, 2})
+	clientStack, clientLink := newTestTCPStack(t, clientAddr)
+	serverStack, serverLink := newTestTCPStack(t, serverAddr)
+
+	go relayTestPackets(ctx, clientLink, serverLink, nil)
+	firstServerFIN := make(chan struct{})
+	secondServerFIN := make(chan struct{})
+	finCount := 0
+	go relayTestPackets(ctx, serverLink, clientLink, func(pkt *stack.PacketBuffer) bool {
+		if testPacketTCPFlags(pkt)&header.TCPFlagFin == 0 {
+			return true
+		}
+		finCount++
+		switch finCount {
+		case 1:
+			close(firstServerFIN)
+			return false
+		case 2:
+			close(secondServerFIN)
+		}
+		return true
+	})
+
+	ln, err := gonet.ListenTCP(serverStack, tcpip.FullAddress{
+		NIC:  testNICID,
+		Addr: serverAddr,
+		Port: 1234,
+	}, ipv4.ProtocolNumber)
+	if err != nil {
+		t.Fatalf("ListenTCP: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan *gonet.TCPConn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c.(*gonet.TCPConn)
+	}()
+	client, err := gonet.DialTCP(clientStack, tcpip.FullAddress{
+		NIC:  testNICID,
+		Addr: serverAddr,
+		Port: 1234,
+	}, ipv4.ProtocolNumber)
+	if err != nil {
+		t.Fatalf("DialTCP: %v", err)
+	}
+	defer client.Close()
+	server := <-accepted
+
+	// Put the server in LAST-ACK: first receive the client's FIN, then send
+	// the server FIN. The packet relay deliberately drops that first FIN.
+	if err := client.CloseWrite(); err != nil {
+		t.Fatalf("client CloseWrite: %v", err)
+	}
+	if _, err := io.Copy(io.Discard, server); err != nil {
+		t.Fatalf("server read to EOF: %v", err)
+	}
+	checkTestTCPState(t, server, tcp.StateCloseWait)
+	if err := server.CloseWrite(); err != nil {
+		t.Fatalf("server CloseWrite: %v", err)
+	}
+	select {
+	case <-firstServerFIN:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not send its first FIN")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		closeProxyConnTimeout(server, time.Second)
+		close(closed)
+	}()
+	select {
+	case <-closed:
+		t.Fatal("closeProxyConn returned before the dropped FIN was retransmitted")
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case <-secondServerFIN:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not retransmit its FIN")
+	}
+	if err := client.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("client SetReadDeadline: %v", err)
+	}
+	if n, err := client.Read(make([]byte, 1)); n != 0 || err != io.EOF {
+		t.Fatalf("client read after retransmitted FIN = %d, %v; want 0, EOF", n, err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		sep, _ := gonetTCPConnInternals(server)
+		cep, _ := gonetTCPConnInternals(client)
+		t.Logf("states: server=%v client=%v", tcp.EndpointState(sep.State()), tcp.EndpointState(cep.State()))
+		t.Fatal("closeProxyConn did not return after the retransmitted FIN was acknowledged")
+	}
+}
 
 func mkLogger(t testing.TB, name string) logger.Logf {
 	return func(format string, args ...any) {


### PR DESCRIPTION
ProxyConns propagates EOF in each direction with CloseWrite, then used to
call Close on both connections as soon as its copy loops returned. For a
gonet.TCPConn, that changes the gVisor endpoint to application-closed
immediately after its FIN was queued. If the FIN is lost around that
transition, the peer can wait forever for EOF.

When the peer FIN has already arrived, subscribe to gVisor’s hangup event
and give the local FIN up to five seconds to be acknowledged before the
final Close. The wait happens entirely inside ProxyConns, is bounded if
the peer disappears, and preserves its simple ownership contract: it
closes both connections before returning.

Together with the outstanding tailscale.com netcheck race fix
(tailscale/tailscale#21086), this completed 12,203 TestServeExitNode runs
over 30 minutes without a failure. The netcheck fix prevents spurious
rebinds; this change independently prevents a lost teardown FIN from
wedging the client.

Updates #71
Updates #73
