### PR TITLE
docs: mention nixpkgs installation, not just Nix flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ Or build from source with a Go toolchain:
 $ go install github.com/tailscale/tailcat/cmd/tailcat@latest
 ```
 
-Or with Nix flakes, run it directly or install it:
+Or with Nix, from [nixpkgs](https://search.nixos.org/packages?channel=unstable&query=tailcat):
+
+```sh
+$ nix profile install nixpkgs#tailcat
+$ nix-env -iA nixpkgs.tailcat  # or with classic nix-env
+```
+
+Or with Nix flakes from this repo, run it directly or install it:
 
 ```sh
 $ nix run github:tailscale/tailcat


### PR DESCRIPTION
tailcat is packaged in nixpkgs now (0.3.0 as of this writing), so
document installing from there alongside the existing flake
instructions.

Fixes #86
