### PR TITLE
tailcat, cmd/tailcat: expose the authenticated peer node key to the served process

### DIFF
--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -420,7 +420,9 @@ to the same port on localhost. Service names are:
 	exit-node    run an exit node for all addresses
 	ssh          SSH server requiring a public key listed by
 	             --ssh-authorized-keys
-	no-auth-ssh  auth-free SSH server (the tunnel provides identity)
+	no-auth-ssh  auth-free SSH server (the tunnel provides identity;
+	             the served process gets the peer's node key in
+	             $TAILCAT_PEER_KEY)
 	files        file server for SFTP clients like scp and sftp,
 	             rooted in the --files directory (default: the
 	             current directory, read-only)

--- a/tailcat_ssh.go
+++ b/tailcat_ssh.go
@@ -24,6 +24,7 @@ import (
 
 	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
+	"tailscale.com/types/key"
 )
 
 const sshInteractiveMOTD = "🐈 Connected via tailcat SSH.\r\n"
@@ -65,7 +66,7 @@ func (s *Server) SSHConnHandler(opts SSHOptions) func(net.Conn) {
 			c.Close()
 			return
 		}
-		handler := sessionHandler
+		handler := s.sessionHandler
 		if !opts.Shell {
 			handler = func(sess ssh.Session) {
 				fmt.Fprintf(sess.Stderr(), "this tailcat server only offers file transfer (SFTP); shell and exec sessions are disabled\r\n")
@@ -94,7 +95,7 @@ func (s *Server) SSHConnHandler(opts SSHOptions) func(net.Conn) {
 }
 
 // sessionHandler handles a single SSH session (shell or exec).
-func sessionHandler(sess ssh.Session) {
+func (s *Server) sessionHandler(sess ssh.Session) {
 	u, err := user.Current()
 	if err != nil {
 		fmt.Fprintf(sess.Stderr(), "failed to get current user: %v\r\n", err)
@@ -112,6 +113,15 @@ func sessionHandler(sess ssh.Session) {
 		}
 	}
 
+	// Surface the connecting peer's authenticated node key to the
+	// served process as TAILCAT_PEER_KEY. The tunnel has already
+	// authenticated the peer by this key (and --allow, if set, gated on
+	// it), so a shell wrapper can tell which allowed peer it's talking
+	// to. The value matches --allow's format ("nodekey:...").
+	if k, ok := s.peerKeyForSession(sess); ok {
+		cmd.Env = append(cmd.Env, "TAILCAT_PEER_KEY="+k.String())
+	}
+
 	ptyReq, winCh, isPTY := sess.Pty()
 	if isPTY && sess.RawCommand() == "" {
 		io.WriteString(sess, sshInteractiveMOTD)
@@ -122,6 +132,19 @@ func sessionHandler(sess ssh.Session) {
 	} else {
 		runWithPipes(sess, cmd)
 	}
+}
+
+// peerKeyForSession returns the node public key of the peer on the
+// other end of sess. The session's remote address is the peer's
+// tailcat IP (derived from its key by tcAddrForKey); peerByIP reverses
+// that back to the key the tunnel authenticated. It returns ok=false
+// if the address can't be mapped to a known peer.
+func (s *Server) peerKeyForSession(sess ssh.Session) (key.NodePublic, bool) {
+	ta, ok := sess.RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		return key.NodePublic{}, false
+	}
+	return s.lb.peerByIP(ta.AddrPort().Addr().Unmap())
 }
 
 // runWithPipes runs cmd with stdin/stdout/stderr pipes (no PTY).

--- a/tailcat_ssh_test.go
+++ b/tailcat_ssh_test.go
@@ -327,6 +327,30 @@ func TestSSHSuite(t *testing.T) {
 		}
 	})
 
+	t.Run("PeerKeyEnv", func(t *testing.T) {
+		// The served process should see the connecting peer's
+		// authenticated node key in TAILCAT_PEER_KEY, matching the
+		// client's own public key (in --allow's "nodekey:..." form).
+		sess, err := env.sshClient(t).NewSession()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sess.Close()
+
+		cmd := "echo peer=$TAILCAT_PEER_KEY"
+		if runtime.GOOS == "windows" {
+			cmd = `echo "peer=$env:TAILCAT_PEER_KEY"`
+		}
+		out, err := sess.Output(cmd)
+		if err != nil {
+			t.Fatalf("Output: %v", err)
+		}
+		want := "peer=" + env.client.PublicKey().String()
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Fatalf("TAILCAT_PEER_KEY = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("PTYAllocated", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("no tty command or /dev tty names on Windows")


### PR DESCRIPTION
Rebasing PR from @seffs in #79, which said:

> With --allow, the tunnel authenticates each client by its node key,
> but the process no-auth-ssh spawns never saw it: sessionHandler runs
> the user's shell and forwards only the env pairs acceptEnvPair lets
> through (TERM, LANG, LC_*), so a wrapper had no way to tell which
> allowed peer connected.
> 
> Set TAILCAT_PEER_KEY on the child's environment to the connecting
> peer's node public key, in the same "nodekey:..." form --allow takes.
> The identity is already in hand at the session: the remote address is
> the peer's tailcat IP (tcAddrForKey), and peerByIP reverses it to the
> key. Every peer completes a meow handshake before any TCP session, so
> the lookup resolves whether or not --allow is set.
> 
> This lets the --allow list itself serve as the identity map, so an
> SSH-certificate bastion no longer needs a second SSH key to recover a
> peer identity the transport already authenticated.
