### PR TITLE
cmd/tailcat: fix genkey --embed-derp-map panic without a fixed region

### DIFF
--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -474,3 +474,109 @@ func TestUnknownArgSelectsRoot(t *testing.T) {
 		t.Errorf("selected command = %q; want root", sel.Name)
 	}
 }
+
+// TestGenkeyEmbedDERPMapRejectsRegionlessModes verifies that
+// --embed-derp-map rejects the --region forms that name no region in
+// the fetched DERP map, rather than dereferencing the missing region
+// and panicking (issue #90).
+func TestGenkeyEmbedDERPMapRejectsRegionlessModes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string // expected substring of the error
+	}{
+		{
+			name: "explicit auto",
+			args: []string{"genkey", "--key=k", "--embed-derp-map", "--region=auto"},
+			want: "mutually exclusive",
+		},
+		{
+			name: "custom DERP hostname",
+			args: []string{"genkey", "--key=k", "--embed-derp-map", "--region=derp1.example.com"},
+			want: "does not take DERP hostnames",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root, err := parseCLI(t, tt.args...)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tt.args, err)
+			}
+			err = root.Run(t.Context())
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("run %q: err = %v; want one containing %q", tt.args, err, tt.want)
+			}
+			var ue usageError
+			if !errors.As(err, &ue) {
+				t.Errorf("run %q: err is not a usageError", tt.args)
+			}
+		})
+	}
+}
+
+// TestGenkeyEmbedDERPMap verifies that --embed-derp-map bakes the
+// region's nodes into the address instead of panicking when --region
+// is left at its "auto" default (issue #90).
+func TestGenkeyEmbedDERPMap(t *testing.T) {
+	e := newTestEnv(t)
+	for _, tt := range []struct {
+		name  string
+		extra []string
+	}{
+		{name: "default region"},
+		{name: "explicit region", extra: []string{"--region=1"}},
+		{name: "fixed region", extra: []string{"--fixed-region"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			keyFile := filepath.Join(t.TempDir(), "server.private.json")
+			args := append([]string{
+				"genkey",
+				"--key=" + keyFile,
+				"--derpmap-url=" + e.derpMapURL,
+				"--embed-derp-map",
+			}, tt.extra...)
+			out, err := e.cmd(args...).Output()
+			if err != nil {
+				t.Fatalf("genkey %q: %v", tt.extra, err)
+			}
+			ci, err := tailcat.ParseAddr(tailcat.Addr(strings.TrimSpace(string(out))))
+			if err != nil {
+				t.Fatalf("ParseAddr: %v", err)
+			}
+			if len(ci.Region) == 0 {
+				t.Fatal("address embeds no DERP region")
+			}
+			if len(ci.Region[0].Nodes) == 0 {
+				t.Error("embedded DERP region has no nodes")
+			}
+			// The embedded region replaces the region ID, so
+			// servers and clients need no DERP map to find it.
+			if ci.RegionID != 0 {
+				t.Errorf("RegionID = %d; want 0 for an embedded region", ci.RegionID)
+			}
+		})
+	}
+}
+
+// TestGenkeyEmbedDERPMapUnknownRegion verifies that naming a region
+// absent from the DERP map fails with a diagnostic rather than a nil
+// map lookup panic (issue #90).
+func TestGenkeyEmbedDERPMapUnknownRegion(t *testing.T) {
+	e := newTestEnv(t)
+	keyFile := filepath.Join(t.TempDir(), "server.private.json")
+	out, err := e.cmd(
+		"genkey",
+		"--key="+keyFile,
+		"--derpmap-url="+e.derpMapURL,
+		"--embed-derp-map",
+		"--region=99999",
+	).CombinedOutput()
+	if err == nil {
+		t.Fatalf("genkey --region=99999 succeeded; want an error\n%s", out)
+	}
+	if bytes.Contains(out, []byte("panic:")) {
+		t.Errorf("genkey panicked:\n%s", out)
+	}
+	if !bytes.Contains(out, []byte("no DERP region 99999")) {
+		t.Errorf("output = %q; want it to name the missing region", out)
+	}
+}

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -126,7 +126,7 @@ func newRootCommand() *ff.Command {
 	genkeyList = genkeyFS.BoolLong("list", "list saved key names and exit")
 	genkeyRegion = genkeyFS.StringLong("region", "auto", "region ID, code, or substring to use. Or a hostname(s) comma-separated to use a custom DERP server(s). If 'auto', one is picked based on latency at each server startup. If 'list', list all regions.")
 	genkeyFixedRegion = genkeyFS.BoolLong("fixed-region", "discover the nearest DERP region once, now, and bake it into the key and tailcat address, so future server startups (and clients) use it without re-probing")
-	genkeyEmbedDERPMap = genkeyFS.BoolLong("embed-derp-map", "embed the DERP map nodes in the tailcat address")
+	genkeyEmbedDERPMap = genkeyFS.BoolLong("embed-derp-map", "embed the DERP map nodes in the tailcat address. Needs a region chosen now, so it implies --fixed-region unless --region names one")
 	genkeyPSK = genkeyFS.BoolLongDefault("psk", true, "include a WireGuard pre-shared key in the generated server key and tailcat address (recommended). Set false only for shorter addresses and compatibility with tailcat clients v0.5.0 and earlier; this weakens security.")
 
 	return &ff.Command{
@@ -1712,6 +1712,21 @@ func genKey(args []string) error {
 		// The empty region means "pick the best region now", below.
 		*region = ""
 	}
+	if *embedDERPMap {
+		// Embedding bakes one region's DERP nodes into the address,
+		// so there has to be a specific region to bake in.
+		switch {
+		case isSet("region") && *region == "auto":
+			return usagef("genkey --embed-derp-map and --region=auto are mutually exclusive; embedding needs a region chosen now, so use --fixed-region or name a region with --region")
+		case strings.Contains(*region, "."):
+			return usagef("genkey --embed-derp-map does not take DERP hostnames in --region; naming hosts already embeds them in the address")
+		case !isSet("region"):
+			// --region defaults to "auto", which has no nodes to
+			// embed, so discover the nearest region now the way
+			// --fixed-region does.
+			*region = ""
+		}
+	}
 	if !keyIsPath(*key) {
 		*key = keyPath(*key)
 		if err := os.MkdirAll(filepath.Dir(*key), 0700); err != nil {
@@ -1803,6 +1818,9 @@ func genKey(args []string) error {
 	}
 	if *embedDERPMap {
 		reg := dm.Regions[ci.RegionID]
+		if reg == nil {
+			log.Fatalf("no DERP region %d in the DERP map; can't embed its nodes", ci.RegionID)
+		}
 		reg.Nodes = reg.Nodes[:min(2, len(reg.Nodes))]
 		for _, n := range reg.Nodes {
 			n.IPv6 = ""


### PR DESCRIPTION
genkey --embed-derp-map looked up dm.Regions[ci.RegionID] and used the
result without checking it. With --region left at its "auto" default,
ci.RegionID is -1, meaning "probe for the nearest region at each server
startup", so the lookup missed and the nil *tailcfg.DERPRegion crashed
on the next line.

Nothing can be embedded in that case: embedding bakes one region's
nodes into the address, which is the opposite of choosing the region
later. Reject an explicit --region=auto as contradictory, and treat the
"auto" default as a request to pick the nearest region now, exactly as
--fixed-region does, since --embed-derp-map already implies a fixed
region.

Two adjacent forms reached the same nil lookup. A --region naming DERP
hostnames leaves RegionID 0 while already embedding those nodes, so it
is now a usage error; a numeric region absent from the DERP map now
names the missing region instead of panicking.

Thanks to Ray Chan for the report!

Fixes #90
