### PR TITLE
cmd/tailcat: fix argument parsing under Termux on Android

### DIFF
--- a/cmd/tailcat/argvfix_termux.go
+++ b/cmd/tailcat/argvfix_termux.go
@@ -1,0 +1,48 @@
+//go:build android
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// termuxPrefix is where the Termux app keeps its filesystem.
+const termuxPrefix = "/data/data/com.termux/files/"
+
+// underTermux reports whether this process was started by Termux.
+//
+// TERMUX_VERSION is set by the Termux shell, but is lost if the process is
+// re-exec'd with a cleared environment, so fall back to checking whether the
+// executable itself lives in the Termux filesystem.
+func underTermux() bool {
+	if os.Getenv("TERMUX_VERSION") != "" {
+		return true
+	}
+	exe, err := os.Executable()
+	return err == nil && strings.HasPrefix(exe, termuxPrefix)
+}
+
+// Android 10+ forbids exec of files in an app's private data directory, so
+// Termux launches binaries through /system/bin/linker64, which inserts the
+// executable's absolute path as os.Args[1]. Drop it so flag parsing sees the
+// real arguments.
+//
+// Nothing outside Termux is touched: a binary run under, say, adb shell keeps
+// os.Args exactly as the kernel delivered it.
+func init() {
+	if !underTermux() {
+		return
+	}
+	if len(os.Args) < 2 || !filepath.IsAbs(os.Args[1]) {
+		return
+	}
+	if filepath.Base(os.Args[1]) != filepath.Base(os.Args[0]) {
+		return
+	}
+	if fi, err := os.Stat(os.Args[1]); err != nil || !fi.Mode().IsRegular() {
+		return
+	}
+	os.Args = append(os.Args[:1:1], os.Args[2:]...)
+}


### PR DESCRIPTION
Android 10+ forbids exec of files in an app's private data directory, so Termux launches binaries through `/system/bin/linker64`, which inserts the executable's absolute path as `os.Args[1]`. flag parsing then reads that path as the destination argument and fails with `invalid DNS name`.

This drops the inserted element, but only after confirming the process really was started by Termux (`TERMUX_VERSION` is set, or the executable lives under `/data/data/com.termux/files/`), so a binary run any other way on Android — `adb shell`, for instance — keeps `os.Args` exactly as the kernel delivered it.

Note that the binary must be built with `-buildmode=pie` for Android to load it at all; the released linux/arm64 binaries are ET_EXEC and are rejected with `has unexpected e_type: 2`.

Tested under Termux on a non-rooted arm64 device.

### Scope

This PR originally also carried a DNS resolver fix and a netmon interface-getter substitute, both needed before tailcat can actually complete a connection under Termux. Per review, those belong in tailscale.com rather than here, so they have been dropped; the argv fix is specific to this CLI's entry point and stands on its own.