### PR TITLE
speed up tests

### DIFF
--- a/cmd/tailcat/cli_test.go
+++ b/cmd/tailcat/cli_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/peterbourgon/ff/v4"
 	"github.com/peterbourgon/ff/v4/ffhelp"
 	"github.com/tailscale/tailcat"
+	"tailscale.com/tstest"
 )
 
 func TestClassifyTailcatAddrArg(t *testing.T) {
@@ -57,6 +58,7 @@ func TestClassifyTailcatAddrArg(t *testing.T) {
 // mentions every subcommand and the global flags, the declarative
 // help dump that motivated the ff port.
 func TestHelpListsCommandTree(t *testing.T) {
+	tstest.AssertNotParallel(t) // newRootCommand rebinds global flag variables
 	help := ffhelp.Command(newRootCommand()).String()
 	for _, want := range []string{
 		"serve", "recv", "ping", "socks", "ssh", "cp", "parse", "resolve",
@@ -83,6 +85,7 @@ func TestHelpListsCommandTree(t *testing.T) {
 // TestServeHelpListsServerFlags verifies that the server-only flags
 // moved off the root command render in the serve subcommand's help.
 func TestServeHelpListsServerFlags(t *testing.T) {
+	tstest.AssertNotParallel(t) // newRootCommand rebinds global flag variables
 	root := newRootCommand()
 	var serve *ff.Command
 	for _, sub := range root.Subcommands {
@@ -150,9 +153,12 @@ func TestParseFilesFlagWriteOnlyModes(t *testing.T) {
 }
 
 // parseCLI parses args against a fresh command tree and returns the
-// root command. It doesn't run anything.
+// root command. It doesn't run anything. The command tree parses into
+// package-level flag variables, so tests that parse must not run in
+// parallel with anything.
 func parseCLI(t *testing.T, args ...string) (root *ff.Command, err error) {
 	t.Helper()
+	tstest.AssertNotParallel(t)
 	root = newRootCommand()
 	return root, root.Parse(args)
 }
@@ -301,6 +307,7 @@ func TestHelpRequests(t *testing.T) {
 // written to stdout, so it can be piped into a pager, while
 // usage-error help stays on stderr, off a pipeline's stdout.
 func TestHelpGoesToStdout(t *testing.T) {
+	t.Parallel()
 	bin := buildTailcat(t)
 	run := func(args ...string) (stdout, stderr string, err error) {
 		var outBuf, errBuf bytes.Buffer
@@ -385,6 +392,7 @@ func TestGenkeyRequiresKeyName(t *testing.T) {
 }
 
 func TestGenkeyPSK(t *testing.T) {
+	t.Parallel()
 	bin := buildTailcat(t)
 	for _, tt := range []struct {
 		name    string
@@ -517,6 +525,7 @@ func TestGenkeyEmbedDERPMapRejectsRegionlessModes(t *testing.T) {
 // region's nodes into the address instead of panicking when --region
 // is left at its "auto" default (issue #90).
 func TestGenkeyEmbedDERPMap(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	for _, tt := range []struct {
 		name  string
@@ -561,6 +570,7 @@ func TestGenkeyEmbedDERPMap(t *testing.T) {
 // absent from the DERP map fails with a diagnostic rather than a nil
 // map lookup panic (issue #90).
 func TestGenkeyEmbedDERPMapUnknownRegion(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	keyFile := filepath.Join(t.TempDir(), "server.private.json")
 	out, err := e.cmd(

--- a/cmd/tailcat/cp_test.go
+++ b/cmd/tailcat/cp_test.go
@@ -71,6 +71,7 @@ func TestCPRejectsInvalidAddr(t *testing.T) {
 // checks that it lands, that a second copy of another name works,
 // and that reading anything back is refused (write-only drop box).
 func TestRecvDropBox(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("scp"); err != nil {
 		t.Skipf("no scp in $PATH: %v", err)
 	}
@@ -114,6 +115,7 @@ func TestRecvDropBox(t *testing.T) {
 // TestCPRoundTrip copies a file to a read-write file server with
 // "tailcat cp" (which runs the system scp) and fetches it back.
 func TestCPRoundTrip(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("scp"); err != nil {
 		t.Skipf("no scp in $PATH: %v", err)
 	}

--- a/cmd/tailcat/e2e_test.go
+++ b/cmd/tailcat/e2e_test.go
@@ -101,6 +101,7 @@ func buildTailcatBinary(dir string) error {
 // nixpkgs' versionCheckHook runs "tailcat --version" and depends on
 // its exit status and output.
 func TestVersionFlag(t *testing.T) {
+	t.Parallel()
 	bin := buildTailcat(t)
 	out, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
@@ -137,11 +138,31 @@ func cacheEnv(t *testing.T) []string {
 	}
 }
 
+// lockedBuf is a bytes.Buffer safe for concurrent use, so tests can
+// read a child process's output while the process is still writing
+// it.
+type lockedBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // waitAddr polls addrFile every 100ms for up to 30 seconds and
 // returns the trimmed tailcat address a tailcat server wrote there via
 // TAILCAT_ADDR_FILE. On timeout it fails the test, including the
 // server's stderr.
-func waitAddr(t *testing.T, addrFile string, stderr *bytes.Buffer) string {
+func waitAddr(t *testing.T, addrFile string, stderr *lockedBuf) string {
 	t.Helper()
 	deadline := time.Now().Add(30 * time.Second)
 	for {
@@ -166,6 +187,22 @@ func skipIfNixSandbox(t *testing.T) {
 	t.Helper()
 	if os.Getenv("NIX_BUILD_TOP") != "" {
 		t.Skip("skipping known-flaky test in the Nix build sandbox")
+	}
+}
+
+// waitForLog polls buf every 10ms until it contains want, failing t
+// after 30 seconds. A child process's output reaches buf through a
+// pipe copied by a goroutine, so it can trail other readiness signals
+// (like the addr file); tests must poll rather than assert on buf's
+// contents at a point in time.
+func waitForLog(t *testing.T, buf *lockedBuf, want string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for !strings.Contains(buf.String(), want) {
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for log output %q; got:\n%s", want, buf.String())
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
@@ -228,10 +265,10 @@ func (e *testEnv) serverCmd(extraFlags ...string) (*exec.Cmd, string) {
 // arranges for it to be killed when the test ends, waits for its
 // tailcat address, and returns the running command, the addr, and the
 // server's captured stderr.
-func (e *testEnv) startServer(extraFlags ...string) (*exec.Cmd, string, *bytes.Buffer) {
+func (e *testEnv) startServer(extraFlags ...string) (*exec.Cmd, string, *lockedBuf) {
 	e.t.Helper()
 	server, addrFile := e.serverCmd(extraFlags...)
-	var stderr bytes.Buffer
+	var stderr lockedBuf
 	server.Stderr = &stderr
 	if err := server.Start(); err != nil {
 		e.t.Fatal(err)

--- a/cmd/tailcat/files_e2e_test.go
+++ b/cmd/tailcat/files_e2e_test.go
@@ -53,6 +53,7 @@ func runSFTPBatch(t *testing.T, e *testEnv, addr, batch string) ([]byte, error) 
 // TestLS lists a read-only file server with the native ls
 // subcommand, which needs no OpenSSH binaries.
 func TestLS(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 
 	serveDir := t.TempDir()
@@ -90,6 +91,7 @@ func TestLS(t *testing.T) {
 // checks that the stock OpenSSH sftp client can fetch a file from it
 // but not write one to it.
 func TestServeFiles(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("sftp"); err != nil {
 		t.Skipf("no sftp client in $PATH: %v", err)
 	}

--- a/cmd/tailcat/forward_test.go
+++ b/cmd/tailcat/forward_test.go
@@ -53,6 +53,7 @@ func TestParseForwardSpec(t *testing.T) {
 }
 
 func TestForwardEndToEnd(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	remotePort := startEchoListener(t)
 
@@ -113,6 +114,7 @@ func TestForwardEndToEnd(t *testing.T) {
 
 func TestForwardToExitNodeTarget(t *testing.T) {
 	skipIfNixSandbox(t) // flaked in the flake sandbox (connection reset mid-tunnel)
+	t.Parallel()
 	e := newTestEnv(t)
 	remotePort := startEchoListener(t)
 	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), remotePort)

--- a/cmd/tailcat/ping_test.go
+++ b/cmd/tailcat/ping_test.go
@@ -15,6 +15,7 @@ import (
 // find a direct localhost path, the same mechanism "tailcat ping
 // --until-direct" users rely on to verify NAT traversal.
 func TestPing(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	_, addr, _ := e.startServer()
 

--- a/cmd/tailcat/pipe_test.go
+++ b/cmd/tailcat/pipe_test.go
@@ -23,6 +23,7 @@ import (
 // (plus TAILCAT_ADDR_FILE) to test the bottles without network
 // access, so it must not regress.
 func TestLocalDERPMode(t *testing.T) {
+	t.Parallel()
 	bin := buildTailcat(t)
 
 	const derpMapURL = "none"
@@ -32,7 +33,8 @@ func TestLocalDERPMode(t *testing.T) {
 	server.Env = append(append(os.Environ(), cacheEnv(t)...),
 		"TS_DEBUG_TAILCAT_LOCAL_DERP=1",
 		"TAILCAT_ADDR_FILE="+addrFile)
-	var serverOut, serverErr bytes.Buffer
+	var serverOut bytes.Buffer
+	var serverErr lockedBuf
 	server.Stdout = &serverOut
 	server.Stderr = &serverErr
 	if err := server.Start(); err != nil {
@@ -76,6 +78,7 @@ func TestLocalDERPMode(t *testing.T) {
 // server must not exit before its FIN is delivered, which once made
 // clients hang forever).
 func TestPipeMode(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 
 	server, addrFile := e.serverCmd()
@@ -83,7 +86,7 @@ func TestPipeMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var serverErr bytes.Buffer
+	var serverErr lockedBuf
 	server.Stderr = &serverErr
 	if err := server.Start(); err != nil {
 		t.Fatal(err)

--- a/cmd/tailcat/serve_test.go
+++ b/cmd/tailcat/serve_test.go
@@ -46,6 +46,7 @@ func startEchoListener(t *testing.T) uint16 {
 }
 
 func TestServeWithoutPSK(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	port := startEchoListener(t)
 	_, addr, serverStderr := e.startServer("serve", "--psk=false", strconv.Itoa(int(port)))
@@ -57,9 +58,7 @@ func TestServeWithoutPSK(t *testing.T) {
 	if !ci.PresharedKey.IsZero() {
 		t.Fatal("serve --psk=false produced an address containing a PSK")
 	}
-	if !strings.Contains(serverStderr.String(), "# ⚠️ WARNING: serving without a WireGuard PSK\n") {
-		t.Errorf("server stderr lacks PSK warning:\n%s", serverStderr.String())
-	}
+	waitForLog(t, serverStderr, "# ⚠️ WARNING: serving without a WireGuard PSK\n")
 
 	const payload = "echo without a pre-shared key"
 	got, err := runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port))), serverStderr, payload)
@@ -72,6 +71,7 @@ func TestServeWithoutPSK(t *testing.T) {
 }
 
 func TestServeRemembersSavedKeyWithoutPSK(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	port := startEchoListener(t)
 	keyFile := filepath.Join(t.TempDir(), "server.private.json")
@@ -83,7 +83,7 @@ func TestServeRemembersSavedKeyWithoutPSK(t *testing.T) {
 	addrFile := filepath.Join(t.TempDir(), "addr")
 	server := e.cmd("--key="+keyFile, "--derpmap-url="+e.derpMapURL, "serve", strconv.Itoa(int(port)))
 	server.Env = append(server.Env, "TAILCAT_ADDR_FILE="+addrFile)
-	var serverStderr bytes.Buffer
+	var serverStderr lockedBuf
 	server.Stderr = &serverStderr
 	if err := server.Start(); err != nil {
 		t.Fatal(err)
@@ -98,10 +98,7 @@ func TestServeRemembersSavedKeyWithoutPSK(t *testing.T) {
 	if !ci.PresharedKey.IsZero() {
 		t.Fatal("saved PSK-free key produced an address containing a PSK")
 	}
-	wantWarning := fmt.Sprintf("# ⚠️ WARNING: saved key %q is not using a WireGuard PSK\n", keyFile)
-	if !strings.Contains(serverStderr.String(), wantWarning) {
-		t.Errorf("server stderr lacks %q:\n%s", wantWarning, serverStderr.String())
-	}
+	waitForLog(t, &serverStderr, fmt.Sprintf("# ⚠️ WARNING: saved key %q is not using a WireGuard PSK\n", keyFile))
 
 	const payload = "echo with saved PSK policy"
 	got, err := runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port))), &serverStderr, payload)
@@ -120,7 +117,7 @@ func TestServeRemembersSavedKeyWithoutPSK(t *testing.T) {
 // waiting out TCP retransmit backoff. On failure, the error includes
 // the client's stderr and the given server stderr (which may be nil),
 // so both sides of a wedged conversation are visible.
-func runClient(t *testing.T, client *exec.Cmd, serverStderr *bytes.Buffer, payload string) (string, error) {
+func runClient(t *testing.T, client *exec.Cmd, serverStderr *lockedBuf, payload string) (string, error) {
 	t.Helper()
 	client.Stdin = strings.NewReader(payload)
 	var stdout, stderr bytes.Buffer
@@ -156,6 +153,7 @@ func runClient(t *testing.T, client *exec.Cmd, serverStderr *bytes.Buffer, paylo
 // port to the same local port, and refuses connections to ports
 // outside the list.
 func TestServePorts(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	port := startEchoListener(t)
 
@@ -178,9 +176,30 @@ func TestServePorts(t *testing.T) {
 		t.Errorf("served port echoed %q; want %q", got, payload)
 	}
 
-	got, err = runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(unservedPort)), serverStderr, payload)
-	if err == nil {
-		t.Errorf("client to unserved port %v succeeded with output %q; want connection failure", unservedPort, got)
+	// The packet filter silently drops SYNs to unserved ports (no
+	// RST; see Server.ServedTCPPorts), so instead of waiting out the
+	// client's whole dial timeout, watch the verbose server's filter
+	// log for the drop and then check the client never got the echo.
+	client := e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(unservedPort))
+	client.Stdin = strings.NewReader(payload)
+	var clientOut bytes.Buffer
+	client.Stdout = &clientOut
+	if err := client.Start(); err != nil {
+		t.Fatal(err)
+	}
+	dropRx := regexp.MustCompile(fmt.Sprintf(`Drop: TCP\{.*\]:%d\}`, unservedPort))
+	deadline := time.Now().Add(30 * time.Second)
+	for !dropRx.MatchString(serverStderr.String()) {
+		if time.Now().After(deadline) {
+			client.Process.Kill()
+			t.Fatalf("server never logged dropping the SYN to unserved port %v; server stderr:\n%s", unservedPort, serverStderr.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	client.Process.Kill()
+	client.Wait()
+	if clientOut.Len() > 0 {
+		t.Errorf("client to unserved port %v got output %q; want none", unservedPort, clientOut.String())
 	}
 }
 
@@ -189,6 +208,7 @@ func TestServePorts(t *testing.T) {
 // client given an IP:port argument and through the SOCKS5 proxy that
 // "tailcat socks" runs.
 func TestServeExitNode(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 	port := startEchoListener(t)
 	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), port)

--- a/cmd/tailcat/socks_test.go
+++ b/cmd/tailcat/socks_test.go
@@ -152,6 +152,7 @@ func TestClassifySOCKSAddr(t *testing.T) {
 // test existed, socks mode ignored --key and could never reach a
 // server locked down with --allow (issue #24).
 func TestSOCKSClientKey(t *testing.T) {
+	t.Parallel()
 	e := newTestEnv(t)
 
 	clientKey := filepath.Join(t.TempDir(), "c.private.json")

--- a/cmd/tailcat/ssh_e2e_test.go
+++ b/cmd/tailcat/ssh_e2e_test.go
@@ -28,6 +28,7 @@ import (
 // dir, and the client runs with StrictHostKeyChecking off and a null
 // known hosts file.
 func TestServeNoAuthSSH(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("ssh"); err != nil {
 		t.Skipf("no ssh client in $PATH: %v", err)
 	}
@@ -56,6 +57,7 @@ func TestServeNoAuthSSH(t *testing.T) {
 }
 
 func TestServeSSHRequiresAuthorizedKeys(t *testing.T) {
+	t.Parallel()
 	bin := buildTailcat(t)
 	out, err := exec.Command(bin, "serve", "ssh").CombinedOutput()
 	if err == nil {
@@ -67,6 +69,7 @@ func TestServeSSHRequiresAuthorizedKeys(t *testing.T) {
 }
 
 func TestServeSSHInteractive(t *testing.T) {
+	t.Parallel()
 	sshExe, err := exec.LookPath("ssh")
 	if err != nil {
 		t.Skipf("no ssh in $PATH: %v", err)

--- a/pickregion.go
+++ b/pickregion.go
@@ -13,6 +13,7 @@ import (
 
 	"tailscale.com/net/netcheck"
 	"tailscale.com/net/netmon"
+	"tailscale.com/net/netns"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/logger"
 )
@@ -22,6 +23,14 @@ import (
 // nil error) if the netcheck report contained no usable region
 // latencies.
 func PickBestRegion(ctx context.Context, dm *tailcfg.DERPMap) (regionID tailcfg.DERPRegionID, err error) {
+	// Disable netns before netcheck binds its STUN sockets, not just
+	// at engine creation as createEngine does, which runs after this.
+	// tailcat has no TUN device whose routes netns would need to
+	// avoid, and netns's unprivileged fallback (SO_BINDTODEVICE to
+	// the default interface) blackholes loopback UDP, making every
+	// netcheck against a loopback DERP map burn the full 3-second
+	// STUN timeout before falling back to HTTPS probes.
+	netns.SetEnabled(false)
 	nc := &netcheck.Client{
 		NetMon:  netmon.NewStatic(),
 		Verbose: Verbose,

--- a/tailcat.go
+++ b/tailcat.go
@@ -77,6 +77,7 @@ import (
 	"tailscale.com/net/dns"
 	"tailscale.com/net/netmon"
 	"tailscale.com/net/netns"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/net/tsdial"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tsd"
@@ -773,7 +774,13 @@ func (s *Server) buildFilter() *filter.Filter {
 		})
 	}
 	local, _ := localNets.IPSet()
-	return filter.New(matches, nil, local, nil, nil, lb.logf)
+	// The logIPs set lets the filter log the packets it drops (the
+	// engine's tstun wrapper asks for drop logging by default), so a
+	// verbose server reports filtered connection attempts instead of
+	// silently eating them. Both endpoints of a flow must be in the
+	// set for it to be logged, so it spans the whole ULA range that
+	// tcAddrForKey assigns from, not just our own address.
+	return filter.New(matches, nil, local, tailcatULASet(), nil, lb.logf)
 }
 
 // Addr returns the server's IPv6 address derived from its public key.
@@ -1652,6 +1659,19 @@ func (b *locoBackend) Status() *ipnstate.Status {
 	return sb.Status()
 }
 
+// tailcatULASet returns the IP set of Tailscale's ULA range that
+// tcAddrForKey assigns tailcat addresses from, for use as a packet
+// filter's logIPs set.
+var tailcatULASet = sync.OnceValue(func() *netipx.IPSet {
+	var b netipx.IPSetBuilder
+	b.AddPrefix(tsaddr.TailscaleULARange())
+	s, err := b.IPSet()
+	if err != nil {
+		panic(err)
+	}
+	return s
+})
+
 func tcAddrForKey(k key.NodePublic) netip.Addr {
 	var a [16]byte
 	r := k.Raw32()
@@ -1867,7 +1887,7 @@ func (c *Client) initLocked() error {
 	localNets := new(netipx.IPSetBuilder)
 	localNets.AddPrefix(lb.addrPrefix)
 	local, _ := localNets.IPSet()
-	e.SetFilter(filter.New(nil, nil, local, nil, nil, logf))
+	e.SetFilter(filter.New(nil, nil, local, tailcatULASet(), nil, logf))
 	dialer.UseNetstackForIP = func(ip netip.Addr) bool {
 		_, ok := lb.peerByIP(ip)
 		return ok

--- a/tailcat_test.go
+++ b/tailcat_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -31,12 +32,42 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"tailscale.com/envknob"
+	"tailscale.com/net/netcheck"
+	"tailscale.com/syncs"
 	"tailscale.com/tailcfg"
 	"tailscale.com/tstest/integration"
 	"tailscale.com/types/key"
 	"tailscale.com/types/logger"
 	"tailscale.com/wgengine/filter"
 )
+
+// TestMain keeps the tests hermetic: engines under test must not
+// touch the real network. The test binary links tailscale.com
+// features that the tailcat library and the released binary omit
+// (build-tags.txt strips them via ts_omit_portmapper and
+// ts_omit_captiveportal), and untagged builds of those features probe
+// the real world during every full netcheck:
+//
+//   - The portmapper sends UPnP/NAT-PMP/PCP queries to the machine's
+//     default gateway, and netcheck blocks its report on the probe
+//     finishing. Home routers can take over a second to answer, which
+//     delayed the engine's DERP connection and made every
+//     engine-starting test that much slower. IN_TS_TEST is
+//     magicsock's own knob for skipping it (netcheck's
+//     SkipExternalNetwork).
+//
+//   - Captive portal detection makes HTTP requests to detection
+//     endpoints across the machine's interfaces, and netcheck also
+//     blocks its report on it. The hook stub reports "done, no
+//     captive portal" immediately.
+func TestMain(m *testing.M) {
+	envknob.Setenv("IN_TS_TEST", "true")
+	netcheck.HookStartCaptivePortalDetection.SetForTest(func(ctx context.Context, c *netcheck.Client, dm *tailcfg.DERPMap, preferredDERP tailcfg.DERPRegionID, setCaptivePortal func(bool)) (done <-chan struct{}, stop func()) {
+		return syncs.ClosedChan(), func() {}
+	})
+	os.Exit(m.Run())
+}
 
 const testNICID = 1
 


### PR DESCRIPTION
- **tailcat, cmd/tailcat: stop netcheck stalling 3s per process, speed up tests**
- **tailcat: keep the tests' netchecks off the real network**
