### PR TITLE
cmd/tailcat: add --log-connections server access log

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,38 @@ stack omits it; transport compression has a history of security
 problems, and TLS dropped it too). Compress files before sending
 if it matters.
 
+### Log incoming connections
+
+By default a server prints its address and then stays quiet. `--log-connections`
+adds an access log on stderr: one line when a client completes the tunnel
+handshake, and one when each of its connections opens and closes.
+
+```sh
+$ tailcat serve --log-connections 8000
+# 🐈 Server listening with new address: tcXXXXXXXXX
+2026/01/30 11:04:02 [peer] allowed key=nodekey:abc123...
+2026/01/30 11:04:02 [conn] open peer=nodekey:abc123... port=8000 service=forward via=derp:sfo
+2026/01/30 11:04:11 [conn] close peer=nodekey:abc123... port=8000 service=forward duration=8.104s
+```
+
+Clients are identified by public key, the same value `--allow` takes, so the
+log and the allowlist name peers the same way. A client's tailcat address is
+derived from its key and so tells you nothing extra; `via` is the only field
+carrying a real network address, and only once a direct path has replaced the
+relay.
+
+With `--allow` set, clients that aren't on the list are logged too, which is
+otherwise invisible:
+
+```
+2026/01/30 11:07:30 [peer] refused key=nodekey:def456... reason=not-in-allow
+```
+
+This is separate from `--verbose`, which turns on the underlying library's
+debug logging. Use `--log-connections` for a record of who connected;
+`--verbose` for diagnosing the tunnel itself. Both can be set at once, and the
+`[peer]` and `[conn]` tags stay greppable either way.
+
 ### Misc commands 
 
 Ping to test connectivity; each pong reports whether it arrived via a

--- a/cmd/tailcat/connlog.go
+++ b/cmd/tailcat/connlog.go
@@ -1,0 +1,98 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"log"
+	"net"
+	"time"
+
+	"github.com/tailscale/tailcat"
+	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
+)
+
+// connLog writes the server-mode access log enabled by
+// --log-connections: one line per peer handshake and per incoming
+// connection, naming the client key the tunnel authenticated and the
+// port or service it reached.
+//
+// It is deliberately separate from --verbose, which turns on the
+// library's debug logging. An operator who wants a record of who
+// connected shouldn't have to read (or store) all of that.
+type connLog struct {
+	logf logger.Logf
+	srv  *tailcat.Server // set by attach, before any event can arrive
+}
+
+// newConnLog returns a connection log writing timestamped lines to
+// stderr, keeping them clear of any data written to stdout.
+func newConnLog() *connLog {
+	return &connLog{logf: log.Printf}
+}
+
+// attach records the server whose events are being logged and installs
+// the peer callback. It must be called before [tailcat.Server.Start].
+func (l *connLog) attach(s *tailcat.Server) {
+	l.srv = s
+	s.OnPeer = l.onPeer
+}
+
+// onPeer is the [tailcat.Server.OnPeer] callback, reporting each
+// client key the first time it completes the tunnel handshake.
+func (l *connLog) onPeer(k key.NodePublic, allowed bool) {
+	if allowed {
+		l.logf("[peer] allowed key=%v", k)
+	} else {
+		l.logf("[peer] refused key=%v reason=not-in-allow", k)
+	}
+}
+
+// wrapTCP returns a handler that logs the connection to dst, given as
+// key=value pairs, around running next.
+//
+// A nil next means the server is about to refuse the connection; that
+// is logged and nil returned, so the server still answers with a RST.
+// The refusal is reported without a peer key because the server
+// decides it from the port alone, before any connection exists to
+// trace back to a peer.
+func (l *connLog) wrapTCP(dst string, next func(net.Conn)) func(net.Conn) {
+	if next == nil {
+		l.logf("[conn] refused %v", dst)
+		return nil
+	}
+	return func(c net.Conn) {
+		peer := "unknown"
+		via := "unknown"
+		if k, ok := l.srv.PeerKeyForConn(c); ok {
+			peer = k.String()
+			via = l.path(k)
+		}
+		l.logf("[conn] open peer=%v %v via=%v", peer, dst, via)
+		start := time.Now()
+		defer func() {
+			l.logf("[conn] close peer=%v %v duration=%v", peer, dst, time.Since(start).Round(time.Millisecond))
+		}()
+		next(c)
+	}
+}
+
+// path reports how packets currently reach peer k: the direct UDP
+// endpoint if one has been negotiated, else the DERP region relaying
+// for it. This is the only place a client's real network address
+// appears, and only once a direct path exists; a client's tailcat
+// address is derived from its key and so says nothing the key doesn't.
+func (l *connLog) path(k key.NodePublic) string {
+	ps, ok := l.srv.Status().Peer[k]
+	if !ok {
+		return "unknown"
+	}
+	switch {
+	case ps.CurAddr != "":
+		return "direct:" + ps.CurAddr
+	case ps.Relay != "":
+		return "derp:" + ps.Relay
+	}
+	return "unknown"
+}

--- a/cmd/tailcat/connlog_test.go
+++ b/cmd/tailcat/connlog_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) Tailscale Inc & contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// clientIdentity generates a saved client key and returns its path and
+// public key string, the form --allow takes.
+func clientIdentity(t *testing.T, e *testEnv) (keyPath, pub string) {
+	t.Helper()
+	keyPath = filepath.Join(t.TempDir(), "c.private.json")
+	if out, err := e.cmd("genkey", "--client", "--key="+keyPath).CombinedOutput(); err != nil {
+		t.Fatalf("genkey: %v\n%s", err, out)
+	}
+	out, err := e.cmd("--key="+keyPath, "printpub").Output()
+	if err != nil {
+		t.Fatalf("printpub: %v", err)
+	}
+	return keyPath, strings.TrimSpace(string(out))
+}
+
+// waitForStderr waits up to 30s for the server's stderr to contain
+// want, returning the buffer contents. Connection log lines for a
+// closing connection can trail the client's exit.
+func waitForStderr(t *testing.T, stderr *bytes.Buffer, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		got := stderr.String()
+		if strings.Contains(got, want) {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server stderr never contained %q:\n%s", want, got)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestServeLogConnections verifies that --log-connections records the
+// authenticated client key for the handshake and for each connection,
+// along with the port and service reached, without needing --verbose.
+func TestServeLogConnections(t *testing.T) {
+	e := newTestEnv(t)
+	port := startEchoListener(t)
+	clientKey, cpub := clientIdentity(t, e)
+
+	_, addr, serverStderr := e.startServer("serve", "--log-connections", strconv.Itoa(int(port)))
+
+	const payload = "logged echo"
+	got, err := runClient(t, e.cmd("--key="+clientKey, "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port))), serverStderr, payload)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if got != payload {
+		t.Errorf("server echoed %q; want %q", got, payload)
+	}
+
+	wantOpen := fmt.Sprintf("[conn] open peer=%v port=%d service=forward via=", cpub, port)
+	logs := waitForStderr(t, serverStderr, wantOpen)
+
+	// Which path the via field names depends on whether a direct path
+	// has displaced the relay by the time the connection opens, so
+	// assert its shape rather than racing that transition.
+	viaRe := regexp.MustCompile(regexp.QuoteMeta(wantOpen) + `(direct:\S+|derp:\S*|unknown)`)
+	if !viaRe.MatchString(logs) {
+		t.Errorf("open line's via field is malformed; want a match for %v:\n%s", viaRe, logs)
+	}
+
+	if want := "[peer] allowed key=" + cpub; !strings.Contains(logs, want) {
+		t.Errorf("server stderr lacks %q:\n%s", want, logs)
+	}
+	// The close line carries a duration, so match its shape.
+	wantClose := regexp.MustCompile(fmt.Sprintf(`\[conn\] close peer=%v port=%d service=forward duration=\S+`, regexp.QuoteMeta(cpub), port))
+	logs = waitForStderr(t, serverStderr, "[conn] close peer="+cpub)
+	if !wantClose.MatchString(logs) {
+		t.Errorf("server stderr lacks a close line matching %v:\n%s", wantClose, logs)
+	}
+}
+
+// TestServeLogConnectionsExitNode verifies that connections an exit
+// node relays onward are logged with the address they were relayed
+// to, which the port-based OnTCP path never sees.
+func TestServeLogConnectionsExitNode(t *testing.T) {
+	e := newTestEnv(t)
+	remotePort := startEchoListener(t)
+	dst := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), remotePort)
+	clientKey, cpub := clientIdentity(t, e)
+
+	_, addr, serverStderr := e.startServer("serve", "--log-connections", "exit-node")
+
+	forward := e.cmd("--verbose", "--key="+clientKey, "--derpmap-url="+e.derpMapURL,
+		"forward", addr, fmt.Sprintf("0:%s", dst))
+	stderrPath := filepath.Join(t.TempDir(), "forward.stderr")
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stderrFile.Close()
+	forward.Stderr = stderrFile
+	if err := forward.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		forward.Process.Kill()
+		forward.Wait()
+	})
+
+	// Wait for the local listener the forward advertises on stderr.
+	addrRx := regexp.MustCompile(`forwarding (\S+) ->`)
+	var local string
+	deadline := time.Now().Add(30 * time.Second)
+	for local == "" {
+		if time.Now().After(deadline) {
+			b, _ := os.ReadFile(stderrPath)
+			t.Fatalf("forward never listened; stderr:\n%s\nserver stderr:\n%s", b, serverStderr)
+		}
+		b, _ := os.ReadFile(stderrPath)
+		if m := addrRx.FindStringSubmatch(string(b)); m != nil {
+			local = m[1]
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	conn, err := net.Dial("tcp", local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := io.WriteString(conn, "exit node echo"); err != nil {
+		t.Fatal(err)
+	}
+
+	want := fmt.Sprintf("[conn] open peer=%v forward=%v via=", cpub, dst)
+	waitForStderr(t, serverStderr, want)
+}
+
+// TestServeLogConnectionsRefusedPeer verifies that a client the
+// --allow list rejects is logged, since a connection log that only
+// showed successful clients would hide exactly the events an operator
+// turned it on to see.
+func TestServeLogConnectionsRefusedPeer(t *testing.T) {
+	e := newTestEnv(t)
+	port := startEchoListener(t)
+	clientKey, cpub := clientIdentity(t, e)
+	_, allowedPub := clientIdentity(t, e)
+
+	// Allow a different identity than the one the client uses.
+	_, addr, serverStderr := e.startServer("serve", "--log-connections", "--allow="+allowedPub, strconv.Itoa(int(port)))
+
+	// The client can't complete the handshake, so it fails; the
+	// server-side refusal is what this test is about.
+	client := e.cmd("--key="+clientKey, "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port)))
+	client.Stdin = strings.NewReader("denied")
+	client.Stdout, client.Stderr = new(bytes.Buffer), new(bytes.Buffer)
+	if err := client.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { client.Process.Kill() })
+
+	want := fmt.Sprintf("[peer] refused key=%v reason=not-in-allow", cpub)
+	logs := waitForStderr(t, serverStderr, want)
+	if strings.Contains(logs, "[conn] open") {
+		t.Errorf("refused peer reached a connection:\n%s", logs)
+	}
+	// The client resends its handshake until it gives up, but a
+	// refused key is only reported once.
+	if n := strings.Count(logs, want); n != 1 {
+		t.Errorf("refusal logged %d times; want 1:\n%s", n, logs)
+	}
+}
+
+// TestServeWithoutLogConnections verifies the flag is off by default,
+// so existing servers' stderr is unchanged.
+func TestServeWithoutLogConnections(t *testing.T) {
+	e := newTestEnv(t)
+	port := startEchoListener(t)
+	_, addr, serverStderr := e.startServer("serve", strconv.Itoa(int(port)))
+
+	const payload = "unlogged echo"
+	got, err := runClient(t, e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, addr, strconv.Itoa(int(port))), serverStderr, payload)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if got != payload {
+		t.Errorf("server echoed %q; want %q", got, payload)
+	}
+	if logs := serverStderr.String(); strings.Contains(logs, "[conn]") || strings.Contains(logs, "[peer]") {
+		t.Errorf("server logged connections without --log-connections:\n%s", logs)
+	}
+}

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -56,6 +56,7 @@ var (
 	flagFiles             *string
 	flagSSHAuthorizedKeys *string
 	flagPSK               *bool
+	flagLogConnections    *bool
 	flagVerbose           *bool
 	flagFullAddress       *bool
 	flagJSON              *bool
@@ -103,6 +104,7 @@ func newRootCommand() *ff.Command {
 	flagFiles = serveFS.StringLong("files", "", "directory to serve to SFTP clients (scp, sftp) with the 'files' service, with an optional :ro (read-only, the default), :rw (read-write), :wo (flat write-only drop box), or :wo+ (recursive write-only drop box) suffix. If empty, the current directory is served read-only. Giving --files implies the 'files' service.")
 	flagSSHAuthorizedKeys = serveFS.StringLong("ssh-authorized-keys", "", "comma-separated SSH public key sources for the 'ssh' service: authorized_keys file paths, literal OpenSSH public key lines, or names like 'alice@github' (fetched from https://github.com/alice.keys). All sources are loaded and validated at startup.")
 	flagPSK = serveFS.BoolLongDefault("psk", true, "include a WireGuard pre-shared key in the tailcat address (recommended). Set false only for shorter addresses and compatibility with tailcat clients v0.5.0 and earlier; this weakens security.")
+	flagLogConnections = serveFS.BoolLong("log-connections", "log an access record to stderr for each client that connects and each connection it opens: the client's public key, the port or service reached, and whether it arrived directly or over a relay. Unlike --verbose, which turns on the library's debug logging, this logs only these events, tagged [peer] and [conn].")
 
 	recvFS := ff.NewFlagSet("recv").SetParent(serveFS)
 	flagRecvAcceptDirs := recvFS.BoolLong("accept-dirs", "accept directory trees (tailcat cp -r), keeping requested file names when available. The trade-off: senders can then make and stat directories and learn whether some names already exist in the drop box. The default flat mode reveals nothing about existing files, but accepts only single files, each saved under a server-chosen unique name.")
@@ -474,6 +476,21 @@ recursive write-only drop box:
 Serve with a saved key (see genkey) and restrict clients:
 
 	tailcat serve --key=default --allow=nodekey:... 22
+
+Keep an access log of who connects and what they reach:
+
+	tailcat serve --log-connections 22,80
+
+which writes lines like these to stderr, independent of --verbose:
+
+	[peer] allowed key=nodekey:abc...
+	[conn] open peer=nodekey:abc... port=22 service=forward via=derp:sfo
+	[conn] close peer=nodekey:abc... port=22 service=forward duration=8.104s
+
+A client is identified by its public key, the same value --allow
+matches on; its tailcat address is derived from that key and so adds
+nothing. The via field is the only place a client's real network
+address appears, and only once a direct path replaces the relay.
 
 Environment:
 
@@ -1398,6 +1415,49 @@ func server(logf logger.Logf, serveSpec string) {
 			return nil // RST
 		}
 		return tcpForwardTo(fmt.Sprintf("localhost:%v", port))
+	}
+
+	if *flagLogConnections {
+		// Several services can share port 22 behind one SSH handler.
+		var sshServiceName string
+		if sshServices {
+			var names []string
+			for _, n := range []string{"ssh", "no-auth-ssh", "files"} {
+				if services.Contains(n) {
+					names = append(names, n)
+				}
+			}
+			sshServiceName = strings.Join(names, "+")
+		}
+		// serviceForPort names what OnTCP hands a connection to,
+		// mirroring the order OnTCP decides in.
+		serviceForPort := func(port uint16) string {
+			switch {
+			case port == 22 && sshHandler != nil:
+				return sshServiceName
+			case services.Contains("exit-node"):
+				return "exit-node"
+			case oneShotStdout:
+				return "stdout"
+			}
+			return "forward"
+		}
+		clog := newConnLog()
+		clog.attach(s)
+		// Wrap the dispatch callbacks, not the connections they
+		// return handlers for: a wrapped net.Conn would hide the
+		// *gonet.TCPConn that ProxyConns needs to shut a tunnel
+		// connection down without losing its FIN.
+		if next := s.OnTCP; next != nil {
+			s.OnTCP = func(port uint16) func(net.Conn) {
+				return clog.wrapTCP(fmt.Sprintf("port=%d service=%v", port, serviceForPort(port)), next(port))
+			}
+		}
+		if next := s.OnTCPForward; next != nil {
+			s.OnTCPForward = func(dst netip.AddrPort) func(net.Conn) {
+				return clog.wrapTCP("forward="+dst.String(), next(dst))
+			}
+		}
 	}
 
 	if err := s.Start(); err != nil {

--- a/tailcat.go
+++ b/tailcat.go
@@ -352,10 +352,15 @@ type locoBackend struct {
 	// peer map lookup. Set before createEngine.
 	onDERPRecv func(regionID tailcfg.DERPRegionID, src key.NodePublic, pkt []byte) bool
 
+	// onPeer is [Server.OnPeer], called with each client key the
+	// first time it completes the handshake. Set before createEngine.
+	onPeer func(k key.NodePublic, allowed bool)
+
 	mu             sync.Mutex
 	clients        map[key.NodePublic]*tailcfg.Node // for the server
 	nm             *netmap.NetworkMap
 	allowedClients map[key.NodePublic]bool // or nil map for all
+	reportedPeers  map[key.NodePublic]bool // refused client keys already passed to onPeer
 	eps            []netip.AddrPort        // our current local UDP endpoints, sorted
 	closeOnce      sync.Once
 }
@@ -490,6 +495,22 @@ type Server struct {
 	// It must be set before calling Start.
 	OnUDPForward func(netip.AddrPort) (handler func(ConnPacketConn))
 
+	// OnPeer, if non-nil, is called the first time a client key
+	// completes the tunnel handshake, with allowed reporting whether
+	// AllowedClients admitted it. A key already reported is not
+	// reported again: clients resend the handshake until it is
+	// acknowledged, and a refused one never is, so reporting every
+	// handshake would repeat a refused key for as long as it retries.
+	// Because a refused key is unauthenticated, only a bounded number
+	// of distinct ones are reported.
+	//
+	// It is called from the packet receive path with no lock held,
+	// before the handshake is acknowledged, so a slow callback delays
+	// the client.
+	//
+	// It must be set before calling Start.
+	OnPeer func(k key.NodePublic, allowed bool)
+
 	// ServedTCPPorts, if non-nil, restricts which TCP ports on the
 	// server's own address the packet filter admits new inbound
 	// connections to. If nil, connections to all ports reach OnTCP,
@@ -586,6 +607,7 @@ func (s *Server) Start() error {
 	for _, k := range s.AllowedClients {
 		mak.Set(&lb.allowedClients, k, true)
 	}
+	lb.onPeer = s.OnPeer
 
 	sys := &lb.sys
 	bus := eventbus.New()
@@ -896,6 +918,42 @@ func (s *Server) AddAllowedClient(k key.NodePublic) {
 	s.lb.mu.Lock()
 	defer s.lb.mu.Unlock()
 	mak.Set(&s.lb.allowedClients, k, true)
+}
+
+// PeerKeyForConn returns the node public key of the peer at the other
+// end of c, a connection or UDP flow handed to an [Server.OnTCP],
+// [Server.OnTCPForward], [Server.OnUDP], or [Server.OnUDPForward]
+// handler. The tunnel has already authenticated the peer by this key,
+// and AllowedClients, if set, gated on it.
+//
+// It reports ok=false if c's remote address is not a known peer's
+// tailcat address, which includes any connection not originating from
+// the tunnel.
+func (s *Server) PeerKeyForConn(c net.Conn) (_ key.NodePublic, ok bool) {
+	return s.peerKeyForAddr(c.RemoteAddr())
+}
+
+// peerKeyForAddr reverses a peer's tailcat address, as reported by an
+// incoming connection's RemoteAddr, back to the node key it was
+// derived from.
+func (s *Server) peerKeyForAddr(a net.Addr) (_ key.NodePublic, ok bool) {
+	if s.lb == nil {
+		return key.NodePublic{}, false // not yet started
+	}
+	var ip netip.Addr
+	switch a := a.(type) {
+	case *net.TCPAddr:
+		ip = a.AddrPort().Addr()
+	case *net.UDPAddr:
+		ip = a.AddrPort().Addr()
+	default:
+		ap, err := netip.ParseAddrPort(a.String())
+		if err != nil {
+			return key.NodePublic{}, false
+		}
+		ip = ap.Addr()
+	}
+	return s.lb.peerByIP(ip.Unmap())
 }
 
 // TailcatAddr returns the tailcat address that clients use to connect to this
@@ -1582,16 +1640,56 @@ func (lb *locoBackend) Start() error {
 // whether the client is allowed and configured, meaning a "meowed"
 // acknowledgment may be sent.
 func (b *locoBackend) onMeow(src key.NodePublic, discoPub key.DiscoPublic) bool {
+	allowed, isNew := b.addMeowPeer(src, discoPub)
+	if b.onPeer != nil {
+		// Allowed clients are deduplicated by the peer set they join;
+		// refused ones join nothing, so they need their own set.
+		report := isNew
+		if !allowed {
+			report = b.markRefusalReported(src)
+		}
+		// Report outside addMeowPeer's lock: the callback is supplied
+		// by the caller and may call back into the server.
+		if report {
+			b.onPeer(src, allowed)
+		}
+	}
+	return allowed
+}
+
+// maxReportedRefusals bounds the set of refused keys onPeer has been
+// told about. A refused handshake is unauthenticated, so anyone who
+// knows the server's address could otherwise grow the set without
+// limit by meowing under invented keys. Past the cap, further refused
+// keys go unreported rather than unbounded.
+const maxReportedRefusals = 1024
+
+// markRefusalReported records that src was refused and handed to
+// onPeer, reporting whether this call was the first to do so.
+func (b *locoBackend) markRefusalReported(src key.NodePublic) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.reportedPeers[src] || len(b.reportedPeers) >= maxReportedRefusals {
+		return false
+	}
+	mak.Set(&b.reportedPeers, src, true)
+	return true
+}
+
+// addMeowPeer adds the client with node key src and disco key
+// discoPub as a WireGuard peer. It reports whether the client is
+// allowed and configured, and whether this call is what added it.
+func (b *locoBackend) addMeowPeer(src key.NodePublic, discoPub key.DiscoPublic) (allowed, isNew bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.logf("got meow from %v", src.String())
 	if b.allowedClients != nil && !b.allowedClients[src] {
 		b.logf("ignoring meow from %v: not in allowedClients", src.String())
-		return false
+		return false, false
 	}
 
 	if _, ok := b.clients[src]; ok {
-		return true
+		return true, false
 	}
 	id := len(b.clients) + 2 // server is ID 1, clients are IDs 2, 3, ...
 	derpRegion := b.derpRegionID()
@@ -1640,13 +1738,15 @@ func (b *locoBackend) onMeow(src key.NodePublic, discoPub key.DiscoPublic) bool 
 	// Tell the new client our UDP endpoints so both sides can attempt
 	// a direct path. Async because advertiseEndpoints takes b.mu.
 	go b.advertiseEndpoints()
-	return true
+	return true, true
 }
 
 func (b *locoBackend) Status() *ipnstate.Status {
 	mc := b.sys.MagicSock.Get()
 	eng := b.sys.Engine.Get()
-	var sb ipnstate.StatusBuilder
+	// magicsock and the engine only fill in Status.Peer, which carries
+	// each peer's relay and direct endpoint, when peers are asked for.
+	sb := ipnstate.StatusBuilder{WantPeers: true}
 	mc.UpdateStatus(&sb)
 	eng.UpdateStatus(&sb)
 	return sb.Status()

--- a/tailcat_ssh.go
+++ b/tailcat_ssh.go
@@ -136,15 +136,11 @@ func (s *Server) sessionHandler(sess ssh.Session) {
 
 // peerKeyForSession returns the node public key of the peer on the
 // other end of sess. The session's remote address is the peer's
-// tailcat IP (derived from its key by tcAddrForKey); peerByIP reverses
-// that back to the key the tunnel authenticated. It returns ok=false
-// if the address can't be mapped to a known peer.
+// tailcat IP, which peerKeyForAddr reverses back to the key the
+// tunnel authenticated. It returns ok=false if the address can't be
+// mapped to a known peer.
 func (s *Server) peerKeyForSession(sess ssh.Session) (key.NodePublic, bool) {
-	ta, ok := sess.RemoteAddr().(*net.TCPAddr)
-	if !ok {
-		return key.NodePublic{}, false
-	}
-	return s.lb.peerByIP(ta.AddrPort().Addr().Unmap())
+	return s.peerKeyForAddr(sess.RemoteAddr())
 }
 
 // runWithPipes runs cmd with stdin/stdout/stderr pipes (no PTY).


### PR DESCRIPTION
### Summary

- Adds `tailcat serve --log-connections`, a per-connection access log on stderr, off by default.
- Logs one line when a client completes the tunnel handshake, and one each when a connection opens and closes.
- Clients are named by public key the same value `--allow` takes  so the log and the allowlist identify peers identically. A client's tunnel address is derived from that key, so logging it would only restate the key.
- The `via` field carries the only real network address: `direct:203.0.113.7:41641` once a direct path forms, `derp:sfo` while still relayed.
- Logs peers refused by `--allow`, previously invisible outside `--verbose` — exactly the events an operator enables an access log to see.
- Exit-node connections log the address they were relayed to (`forward=...`), which the port-based path never sees.
- Independent of `--verbose`; both can be set at once, and the `[peer]` / `[conn]` tags stay greppable either way.
- Adds `Server.OnPeer` and `Server.PeerKeyForConn`; the SSH path's `peerKeyForSession` drops its duplicated lookup in favour of the latter.
- Fixes `locoBackend.Status()` building its `StatusBuilder` without `WantPeers`, which magicsock and the engine both gate peer population on  `Server.Status()` was returning zero peers to every caller. This is what makes `via` resolve.

### Tests

- `TestServeLogConnections`  handshake, open, and close lines carry the authenticated client key, port, and service, without `--verbose`.
- `TestServeLogConnectionsExitNode`  relayed connections log the forwarded-to address.
- `TestServeLogConnectionsRefusedPeer`  an `--allow`-rejected client is logged, reaches no connection, and is reported exactly once despite handshake retries.
- `TestServeWithoutLogConnections` — flag off by default; existing servers' stderr is unchanged.
- Full suite passes; `go vet` clean.
