### PR TITLE
cmd/tailcat, README.md: warn when a DNS-named SSH destination is wide open

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ $ tailcat serve no-auth-ssh
 # 🐈 Server listening with new address: tcXXXXXXXXX
 ```
 
+> [!WARNING]
+> With `no-auth-ssh`, the address **is** the credential: anyone who
+> learns it gets a shell as the user running the server. Share it only
+> over private channels, and never publish it, in a DNS TXT record or
+> anywhere else public. If you want an SSH server reachable by DNS
+> name, it must require client authentication: `--allow` at the tunnel
+> layer, `--ssh-authorized-keys` at the SSH layer, or both.
+
 And on the client side:
 
 ```sh
@@ -425,6 +433,20 @@ $ tailcat ssh example.com
 $ tailcat ping example.com
 ```
 
+> [!WARNING]
+> A tailcat address is normally a secret: knowing it is what lets a
+> client connect. A DNS TXT record is **not** secret. It is public,
+> world-readable, and actively scanned. Publishing an address in DNS
+> hands it to everyone on the internet, so the server behind it must
+> authenticate clients by something other than knowledge of the
+> address: restrict the tunnel to known client keys with `tailcat
+> serve --allow=...`, or, for SSH, require public keys with `tailcat
+> serve --ssh-authorized-keys=... ssh`. Never publish the address of a
+> `no-auth-ssh` server (or any other server that trusts whoever
+> connects): that is a shell on your machine, published in a TXT
+> record. See [Protected SSH server over
+> DNS](#protected-ssh-server-over-dns) for the safe setup.
+
 ## Examples
 
 ### Protected SSH server over DNS
@@ -433,6 +455,14 @@ Who needs port forwarding or port knocking? This runs an SSH server
 reachable from anywhere by name, with no open inbound ports on the
 server, where WireGuard authenticates the client before the SSH
 server ever sees a packet.
+
+> [!WARNING]
+> The `--allow` flag below is not optional decoration. The DNS TXT
+> record makes the tailcat address public, so possession of the
+> address no longer proves anything: the server must authenticate
+> clients itself, here by allowing only one client node key. Without
+> `--allow` (or SSH-level `--ssh-authorized-keys`), anyone on the
+> internet who reads the TXT record can connect.
 
 On the client machine, generate a client identity keypair. It prints
 the public key, which is all the server needs to know:
@@ -471,6 +501,16 @@ Client modes automatically use the saved `client-default` key when it
 exists, so no extra flags are needed to present the allowed identity.
 Anyone else's handshake is silently ignored: they can't reach the SSH
 server, or even learn that one is running.
+
+As a safety net, `tailcat ssh` probes a DNS-named destination before
+connecting: it attempts an SSH login as a stranger would, with a
+freshly generated client key and no SSH credentials. If the server
+accepts that login, anyone who reads the TXT record could do the
+same, so tailcat refuses to connect and says why. The probe
+catches the misconfiguration the first time you test your own server;
+the `--skip-dns-safety-check` flag skips it, whether because you
+really do want a public server or just to shave off the probe's
+round trips.
 
 Why `--fixed-region`: it discovers the nearest DERP region once, at
 genkey time, and bakes its ID into both the printed tailcat address and the
@@ -646,6 +686,10 @@ With embedded DERP node details it's longer but self-contained.
 
 The default address is a secret bearer capability because it contains the
 pre-shared key. Share it only with clients that should be able to connect.
+Publishing it, in a public DNS TXT record or anywhere else, gives that
+capability to the whole internet, which is only safe when the server also
+authenticates clients: `serve --allow` restricts the tunnel to listed
+client node keys, and the `ssh` service requires `--ssh-authorized-keys`.
 
 ### Network stack
 

--- a/cmd/tailcat/cp.go
+++ b/cmd/tailcat/cp.go
@@ -79,7 +79,7 @@ func clientCPMode(recursive, preserve bool, portOrIPPort string, args []string) 
 	if addr == "" {
 		return usagef("no remote <tc-addr>:path argument; nothing to copy through tailcat")
 	}
-	addr, err = validatedAddr(addr)
+	addr, _, err = validatedAddr(addr)
 	if err != nil {
 		return err
 	}

--- a/cmd/tailcat/ssh.go
+++ b/cmd/tailcat/ssh.go
@@ -11,15 +11,21 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"net"
 	"net/netip"
 	"os"
 	"os/exec"
+	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v4"
 	"github.com/tailscale/tailcat"
+	gossh "golang.org/x/crypto/ssh"
+	"tailscale.com/types/key"
+	"tailscale.com/types/logger"
 )
 
 const tailCatSSHEnabled = true
@@ -41,6 +47,14 @@ remote command to run.
 A DNS name whose "tailcat=" TXT record holds a tailcat address works
 as the destination too.
 
+A DNS TXT record is public, so a DNS-named destination is first
+probed the way a stranger would connect: with a freshly generated
+client key and no SSH credentials. If the server lets that stranger
+log in, tailcat refuses to connect, because anyone on the internet
+who reads the TXT record could do the same. The
+--skip-dns-safety-check flag skips the probe, either to connect
+anyway or to save the probe's round trips.
+
 The -p flag is the server port to connect to (default 22), or, if
 the server is an exit node (--serve=exit-node), an ip:port on the
 server's network to reach through it; a bare IP means its port 22.`
@@ -50,6 +64,7 @@ server's network to reach through it; a bare IP means its port 22.`
 func sshCommand(parent *ff.FlagSet) *ff.Command {
 	fs := ff.NewFlagSet("ssh").SetParent(parent)
 	port := fs.StringShort('p', "22", "port number, or ip:port to reach via the server's exit node; a bare IP means port 22 on it")
+	skipDNSCheck := fs.BoolLong("skip-dns-safety-check", "don't probe a DNS-named destination for whether its server gives SSH access to strangers (anyone who reads its public TXT record); skipping also saves the probe's round trips")
 	return &ff.Command{
 		Name:      "ssh",
 		Usage:     "tailcat ssh [-p <port|ip:port>] [user@]<tc-addr> [<command> [args...]]",
@@ -57,12 +72,12 @@ func sshCommand(parent *ff.FlagSet) *ff.Command {
 		LongHelp:  sshLongHelp,
 		Flags:     fs,
 		Exec: func(ctx context.Context, args []string) error {
-			return clientSSHMode(*port, args)
+			return clientSSHMode(*port, *skipDNSCheck, args)
 		},
 	}
 }
 
-func clientSSHMode(portOrIPPort string, args []string) error {
+func clientSSHMode(portOrIPPort string, skipDNSCheck bool, args []string) error {
 	if len(args) == 0 {
 		return usagef("ssh requires a [user@]<tc-addr> destination argument")
 	}
@@ -78,9 +93,13 @@ func clientSSHMode(portOrIPPort string, args []string) error {
 		addrStr = sshUser
 		sshUser = ""
 	}
-	addrStr, err = validatedAddr(addrStr)
+	dnsName := addrStr
+	addrStr, viaDNS, err := validatedAddr(addrStr)
 	if err != nil {
 		return err
+	}
+	if viaDNS && !skipDNSCheck {
+		refuseWideOpenDNS(dnsName, addrStr, portOrIPPort, sshUser)
 	}
 	exe, err := os.Executable()
 	if err != nil {
@@ -131,15 +150,105 @@ func validatedSSHPort(v string) (string, error) {
 
 // validatedAddr resolves arg if it is a DNS name and verifies that the
 // result is a valid tailcat address before it is handed to ssh or scp.
-func validatedAddr(arg string) (string, error) {
-	addr := tailcat.Addr(arg)
+// viaDNS reports whether the address came from a public DNS TXT record
+// rather than being supplied directly.
+func validatedAddr(arg string) (addr string, viaDNS bool, err error) {
+	a := tailcat.Addr(arg)
 	if strings.Contains(arg, ".") {
-		addr = tailcatAddrArg(arg)
+		a = tailcatAddrArg(arg)
+		viaDNS = true
 	}
-	if _, err := tailcat.ParseAddr(addr); err != nil {
-		return "", fmt.Errorf("invalid tailcat address %q: %w", arg, err)
+	if _, err := tailcat.ParseAddr(a); err != nil {
+		return "", false, fmt.Errorf("invalid tailcat address %q: %w", arg, err)
 	}
-	return string(addr), nil
+	return string(a), viaDNS, nil
+}
+
+// refuseWideOpenDNS probes the server whose tailcat address addr came
+// from the public DNS TXT record of dnsName, and exits the process
+// with a warning if the server gives SSH access to strangers. Probe
+// failures are not fatal: a server protected by --allow ignores
+// strangers entirely, so the probe times out, and any other failure
+// recurs in the real connection that follows, with a better error.
+func refuseWideOpenDNS(dnsName, addr, portOrIPPort, sshUser string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	open, err := probeStrangerSSH(ctx, getLogf(), *flagDERPMapURL, addr, portOrIPPort, sshUser)
+	if err != nil {
+		if *flagVerbose {
+			log.Printf("stranger probe of %s did not connect: %v", dnsName, err)
+		}
+		return
+	}
+	if !open {
+		return
+	}
+	log.Fatalf(`⚠️ WARNING: refusing to connect to %s: its SSH server is wide open.
+
+The tailcat address in its DNS TXT record is public, and the server
+accepted an SSH login from a freshly generated client key offering
+no SSH credentials at all. Anyone on the internet who reads that DNS
+record can get a shell.
+
+If that's your server, stop running it now, and restart it only once
+it requires client authentication:
+
+  tailcat serve --allow=<client-nodekey> ...        (tunnel layer)
+  tailcat serve --ssh-authorized-keys=<keys> ssh    (SSH layer)
+
+Or, to connect anyway, re-run with --skip-dns-safety-check.`, dnsName)
+}
+
+// probeStrangerSSH reports whether the tailcat server at addr grants
+// SSH access to a stranger. It connects with a freshly generated node
+// key and attempts an SSH handshake as sshUser (the local username if
+// empty, matching the ssh client's default) offering no credentials,
+// only the "none" auth method, which the no-auth-ssh service accepts
+// before public key auth would even come up. It makes no command or
+// PTY request and disconnects. Open false with a nil error means the
+// server rejected the stranger's handshake.
+func probeStrangerSSH(ctx context.Context, logf logger.Logf, derpMapURL, addr, portOrIPPort, sshUser string) (open bool, err error) {
+	cl := &tailcat.Client{
+		Server:       tailcat.Addr(addr),
+		Key:          key.NewNode(),
+		Logf:         logf,
+		DERPMapURL:   derpMapURL,
+		DERPMapCache: derpMapCache{},
+	}
+	var conn net.Conn
+	if ipPort, err2 := netip.ParseAddrPort(portOrIPPort); err2 == nil {
+		conn, err = cl.DialTCP(ctx, ipPort)
+	} else {
+		port, err2 := strconv.ParseUint(portOrIPPort, 10, 16)
+		if err2 != nil {
+			return false, fmt.Errorf("invalid port %q", portOrIPPort)
+		}
+		conn, err = cl.DialTCPPort(ctx, uint16(port))
+	}
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetDeadline(deadline)
+	}
+
+	if sshUser == "" {
+		u, err := user.Current()
+		if err != nil {
+			return false, err
+		}
+		sshUser = u.Username
+	}
+	sc, chans, reqs, err := gossh.NewClientConn(conn, addr, &gossh.ClientConfig{
+		User:            sshUser,
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		return false, nil
+	}
+	gossh.NewClient(sc, chans, reqs).Close()
+	return true, nil
 }
 
 // sshProxyCommand returns the command passed to OpenSSH to connect the SSH

--- a/cmd/tailcat/ssh_e2e_test.go
+++ b/cmd/tailcat/ssh_e2e_test.go
@@ -10,12 +10,18 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+	"tailscale.com/types/key"
 )
 
 // TestServeNoAuthSSH runs a --serve=no-auth-ssh server and connects
@@ -53,6 +59,59 @@ func TestServeNoAuthSSH(t *testing.T) {
 	// TrimSpace: PowerShell on Windows emits "hi\r\n".
 	if got, want := strings.TrimSpace(string(out)), "hi"; got != want {
 		t.Errorf("tailcat ssh output = %q; want %q", got, want)
+	}
+}
+
+// TestProbeStrangerSSH exercises the wide-open-DNS probe against the
+// three kinds of SSH servers: a no-auth-ssh server grants a stranger
+// access via the "none" auth method, an authorized-keys server
+// rejects the credential-less stranger, and a --allow server ignores
+// the stranger's tunnel handshake entirely, so the probe times out
+// with an error. Not
+// parallel: the probe runs in-process, and t.Setenv points its DERP
+// map cache at a temp dir instead of the real user cache.
+func TestProbeStrangerSSH(t *testing.T) {
+	e := newTestEnv(t)
+	for _, kv := range cacheEnv(t) {
+		k, v, _ := strings.Cut(kv, "=")
+		t.Setenv(k, v)
+	}
+
+	probe := func(addr string, timeout time.Duration) (bool, error) {
+		ctx, cancel := context.WithTimeout(t.Context(), timeout)
+		defer cancel()
+		return probeStrangerSSH(ctx, t.Logf, e.derpMapURL, addr, "22", "stranger")
+	}
+
+	_, addr, _ := e.startServer("--serve=no-auth-ssh")
+	if open, err := probe(addr, 30*time.Second); err != nil {
+		t.Fatalf("probe of no-auth-ssh server: %v", err)
+	} else if !open {
+		t.Errorf("probe of no-auth-ssh server = not wide open; want wide open")
+	}
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshPub, err := gossh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authKeys := filepath.Join(t.TempDir(), "authorized_keys")
+	if err := os.WriteFile(authKeys, gossh.MarshalAuthorizedKey(sshPub), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, addr, _ = e.startServer("serve", "--ssh-authorized-keys="+authKeys, "ssh")
+	if open, err := probe(addr, 30*time.Second); err != nil {
+		t.Fatalf("probe of authorized-keys server: %v", err)
+	} else if open {
+		t.Errorf("probe of authorized-keys server = wide open; want rejected")
+	}
+
+	_, addr, _ = e.startServer("serve", "--allow="+key.NewNode().Public().String(), "no-auth-ssh")
+	if open, err := probe(addr, 5*time.Second); err == nil {
+		t.Errorf("probe of --allow server = %v, nil; want a timeout error", open)
 	}
 }
 

--- a/cmd/tailcat/ssh_test.go
+++ b/cmd/tailcat/ssh_test.go
@@ -28,7 +28,7 @@ func TestSSHRejectsInvalidAddr(t *testing.T) {
 		{"invalid CBOR", "tc" + base64.RawURLEncoding.EncodeToString([]byte("not CBOR")), "CBOR unmarshal"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := clientSSHMode("22", []string{tt.addr})
+			err := clientSSHMode("22", false, []string{tt.addr})
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("clientSSHMode(%q) error = %v; want an error containing %q", tt.addr, err, tt.wantErr)
 			}


### PR DESCRIPTION
A tailcat address published in a DNS TXT record is public, so the
server behind it must authenticate clients by something other than
possession of the address (--allow or --ssh-authorized-keys). People
were missing that connection and publishing no-auth-ssh servers in
DNS, handing a shell to anyone who reads the record.

Make the README say this explicitly in every section that touches
DNS TXT records or auth-free SSH, and make "tailcat ssh" catch the
misconfiguration: before connecting to a DNS-named destination, probe
the server the way a stranger would, with a freshly generated node
key and no SSH credentials, only the "none" auth method that the
no-auth-ssh service accepts. The probe authenticates only, with no
command or PTY request. If the server accepts the stranger, refuse
to connect and explain how to lock it down, unless the new
--skip-dns-safety-check flag is set (which also saves the probe's
round trips). Probe failures are not fatal: a --allow-protected
server ignores strangers entirely, so the probe just times out and
the real connection proceeds.

This can't catch someone who publishes an open server and never
connects to it, but the common path is to test your own server right
after setting it up, and the first such test now sounds the alarm.

Fixes #100
