### PR TITLE
cmd/tailcat: warn about public DNS in root help and at no-auth-ssh startup

### DIFF
--- a/cmd/tailcat/ssh_e2e_test.go
+++ b/cmd/tailcat/ssh_e2e_test.go
@@ -40,7 +40,8 @@ func TestServeNoAuthSSH(t *testing.T) {
 	}
 	e := newTestEnv(t)
 
-	_, addr, _ := e.startServer("--serve=no-auth-ssh")
+	_, addr, stderr := e.startServer("--serve=no-auth-ssh")
+	waitForLog(t, stderr, "# ⚠️ WARNING: no-auth-ssh gives a shell to anyone with this address; keep it secret (never in a DNS TXT record) or restrict clients with --allow\n")
 
 	client := e.cmd("--key=new", "--derpmap-url="+e.derpMapURL, "ssh", addr, "echo", "hi")
 	done := make(chan struct{})

--- a/cmd/tailcat/tailcat.go
+++ b/cmd/tailcat/tailcat.go
@@ -324,6 +324,12 @@ Anywhere a <tc-addr> argument is accepted, a DNS name whose
 
 	tailcat ssh example.com
 
+But beware: a tailcat address is normally a secret, and a DNS TXT
+record is public, so a server named in DNS must authenticate its
+clients some other way: --allow at the tunnel layer, or the ssh
+service's --ssh-authorized-keys. Never publish a no-auth-ssh server's
+address; that gives a shell to anyone who reads the TXT record.
+
 Client mode, ping. Each pong reports whether it arrived via a DERP
 relay or a direct path. --until-direct keeps pinging (bounded by
 --timeout, default 10s) until a direct path works:
@@ -1409,6 +1415,9 @@ func server(logf logger.Logf, serveSpec string) {
 		} else {
 			fmt.Fprintf(os.Stderr, "# ⚠️ WARNING: saved key %q is not using a WireGuard PSK\n", *flagKey)
 		}
+	}
+	if sshWithoutAuth && *flagAllow == "" {
+		fmt.Fprintln(os.Stderr, "# ⚠️ WARNING: no-auth-ssh gives a shell to anyone with this address; keep it secret (never in a DNS TXT record) or restrict clients with --allow")
 	}
 	if devDERP != nil {
 		// Wait until we're connected to our own dev DERP before


### PR DESCRIPTION
The README warns loudly that a tailcat address published in a DNS TXT
record is public, but the CLI barely did: the root help presented
"tailcat ssh example.com" with no caveats (and got quoted on social
media as encouraging people to put access to their machines in public
DNS), and "tailcat serve no-auth-ssh" started silently even though
its address is the only credential.

Add the missing warning paragraph to the root help's DNS section, and
print a one-line startup warning when serving no-auth-ssh without
--allow, in the style of the existing PSK warning.

Updates #100
